### PR TITLE
Fixed Image Embedding

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ NodeID3.prototype.createPictureFrame = function(filepath) {
             mime_type = "image/jpeg";
         }
 
-        var bContent = new Buffer((mime_type.length + 4).toString(), 'binary');
+        var bContent = new Buffer(mime_type.length + 4);
         bContent.fill(0);
         bContent.write(mime_type, 1);
 

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ NodeID3.prototype.createPictureFrame = function(filepath) {
             mime_type = "image/jpeg";
         }
 
-        var bContent = new Buffer(mime_type.length + 4, 'binary');
+        var bContent = new Buffer((mime_type.length + 4).toString(), 'binary');
         bContent.fill(0);
         bContent.write(mime_type, 1);
 


### PR DESCRIPTION
Fixed Error: If encoding is specified then the first argument must be a
string at NodeID3.createPictureFrame (/node-id3/index.js:177:24)