### PR TITLE
removing trailing spaces + bug fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -615,27 +615,23 @@ NodeID3.prototype.createCommentFrame = function(comment) {
 **  frame   => Buffer
 */
 NodeID3.prototype.readCommentFrame = function(frame) {
-    var tags = {}
-
+    let tags = {}
     if(!frame) {
         return tags
     }
-
     let encoding = false
     let start = 1
-
-    if(frame[0] == 0) {
+    if(frame[0] == 0x00) {
         encoding = 'ascii'
-    } else if(frame[0] == 1) {
-        bytes1to5 = frame.slice(1,6).toString('hex')
+    } else if(frame[0] == 0x01) {
+        let bytes1to5 = frame.slice(1, 6).toString('hex')
         if(bytes1to5 == '0000000000') {
-            if(frame[6]==255 && frame[7]== 254) {
+            if(frame[6] == 0xFF && frame[7] == 0xFE) {
                 encoding = 'utf16le'
                 start = 8
             }
         }
     }
-
     if(encoding) {
         let arr = frame.slice(start).toString(encoding).split('\0')
         if(arr.length == 1) {
@@ -650,6 +646,5 @@ NodeID3.prototype.readCommentFrame = function(frame) {
             }
         }
     }
-
     return tags
 }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const iconv = require("iconv-lite")
 
 module.exports = new NodeID3
 
-/*  
+/*
 **  Used specification: http://id3.org/id3v2.3.0
 */
 
@@ -224,7 +224,7 @@ NodeID3.prototype.read = function(filebuffer, options, fn) {
         if(typeof filebuffer === "string" || filebuffer instanceof String) {
             fs.readFile(filebuffer, function(err, data) {
                 if(err) {
-                    fn(err, tags)
+                    fn(err, null)
                 } else {
                     let tags = this.getTagsFromBuffer(data, options)
                     fn(null, tags)
@@ -381,7 +381,7 @@ NodeID3.prototype.getFrameSize = function(buffer, decode) {
 **  Checks and removes already written ID3-Frames from a buffer
 **  data => buffer
 */
-NodeID3.prototype.removeTagsFromBuffer = function(data) {    
+NodeID3.prototype.removeTagsFromBuffer = function(data) {
     let framePosition = this.getFramePosition(data)
     let hSize = new Buffer([data[framePosition + 6], data[framePosition + 7], data[framePosition + 8], data[framePosition + 9]])
 
@@ -406,12 +406,12 @@ NodeID3.prototype.removeTags = function(filepath, fn) {
         } catch(e) {
             return e
         }
-    
+
         let newData = this.removeTagsFromBuffer(data)
-        if(!newData) { 
+        if(!newData) {
             return false
         }
-    
+
         try {
             fs.writeFileSync(filepath, newData, 'binary')
         } catch(e) {
@@ -424,7 +424,7 @@ NodeID3.prototype.removeTags = function(filepath, fn) {
             if(err) {
                 fn(err)
             }
-            
+
             let newData = this.removeTagsFromBuffer(data)
             if(!newData) {
                 fn(err)
@@ -601,7 +601,7 @@ NodeID3.prototype.createCommentFrame = function(comment) {
     } else {
         commentOptions.write("eng", 1)
     }
-    
+
     let commentText = new Buffer(iconv.encode(comment.text, "utf16"))
 
     comment.shortText = comment.shortText || ""
@@ -616,6 +616,7 @@ NodeID3.prototype.createCommentFrame = function(comment) {
 */
 NodeID3.prototype.readCommentFrame = function(frame) {
     let tags = {}
+
     if(!frame) {
         return tags
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-id3",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pure JavaScript ID3 Tag writer/reader",
   "author": "Jan Metzger <jan.metzger@gmx.net>",
   "main": "index.js",


### PR DESCRIPTION
- removed some trailing spaces
- In line 227, an error `tags is not defined` occured, when a file was not readable
- improving of `readCommentFrame()`:

The function tried to allocate a negative buffer size when the comment tag was encoded with utf-16 and ended with an error, so I've improved it a little bit.

It might not be perfect yet but it's much better then before.

And furthermore, MP3 files can have multiple comments, which is not supported yet.


