### PR TITLE
Check encoding for COMM tags on read

### DIFF
--- a/index.js
+++ b/index.js
@@ -436,7 +436,7 @@ NodeID3.prototype.getTagsFromBuffer = function(filebuffer, options) {
 
     frames.forEach(function(frame, index) {
         //  Check first character if frame is text frame
-        if(frame.name[0] === "T" && frame.name !== "TXXX") {
+        if((frame.name[0] === "T" && frame.name !== "TXXX") || frame.name === "COMM") {
             //  Decode body
             let decoded
             if(frame.body[0] === 0x01) {


### PR DESCRIPTION
- COMM tags have an associated encoding which needs to be handled
  - See: http://id3.org/id3v2.3.0#Comments
- We have some mp3s that have LATIN-1 encoded COMM tags,
  which cannot be read by the current version of the code.
- This commit re-uses the existing encoding check used by text tags
  to also decode COMM.