### PR TITLE
changed "private" variable to "_private"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1114,15 +1114,15 @@ NodeID3.prototype.readPopularimeterFrame = function(frame) {
 }
 
 /*
-**  private => object|array {
+**  _private => object|array {
 **      ownerIdentifier:    string,
 **      data:   buffer|string
 **  }
 **/
-NodeID3.prototype.createPrivateFrame = function(private) {
-    if(private instanceof Array && private.length > 0) {
+NodeID3.prototype.createPrivateFrame = function(_private) {
+    if(_private instanceof Array && _private.length > 0) {
         let frames = []
-        private.forEach(tag => {
+        _private.forEach(tag => {
             let frame = this.createPrivateFrameHelper(tag)
             if(frame) {
                 frames.push(frame)
@@ -1130,22 +1130,22 @@ NodeID3.prototype.createPrivateFrame = function(private) {
         })
         return frames.length ? Buffer.concat(frames) : null
     } else {
-        return this.createPrivateFrameHelper(private)
+        return this.createPrivateFrameHelper(_private)
     }
 }
 
-NodeID3.prototype.createPrivateFrameHelper = function(private) {
-    if(!private || !private.ownerIdentifier || !private.data) {
+NodeID3.prototype.createPrivateFrameHelper = function(_private) {
+    if(!_private || !_private.ownerIdentifier || !_private.data) {
         return null;
     }
     let header = Buffer.alloc(10, 0)
     header.write("PRIV")
-    let ownerIdentifier = Buffer.from(private.ownerIdentifier + "\0", "utf8")
+    let ownerIdentifier = Buffer.from(_private.ownerIdentifier + "\0", "utf8")
     let data
-    if(typeof(private.data) == "string") {
-        data = Buffer.from(private.data, "utf8")
+    if(typeof(_private.data) == "string") {
+        data = Buffer.from(_private.data, "utf8")
     } else {
-        data = private.data
+        data = _private.data
     }
 
     header.writeUInt32BE(ownerIdentifier.length + data.length, 4)


### PR DESCRIPTION
Starting with version 0.1.14 you added some code that includes "private" variable.
https://github.com/Zazama/node-id3/blob/master/index.js#L1122

This name is reserved in javascript and should not be used as a variable.
https://www.w3schools.com/js/js_reserved.asp

Now, code with your library can't be compiled with some of popular building systems.
for example, [terser](https://github.com/webpack-contrib/terser-webpack-plugin/) throws an error when we use "private" as a variable in code.

I changed the variable name.