### PR TITLE
Passed arguments everywhere to buffer.readUInt32BE() to avoid some errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1105,7 +1105,7 @@ NodeID3.prototype.readPopularimeterFrame = function(frame) {
             if(counterIndex < frame.length) {
                 let value = frame.slice(counterIndex, frame.length)
                 if(value.length >= 4) {
-                    tags.counter = value.readUInt32BE()
+                    tags.counter = value.readUInt32BE(0)
                 }
             }
         }


### PR DESCRIPTION
https://github.com/webpack/node-libs-browser/issues/93

Webpack 4 now is a stable version. It uses node-libs for Buffer polyfill that is not completely compatible with the nodejs implementation. In node-libs a lot of optional arguments are required, so we get an offset error in the browser calling buffer.readUInt32BE without an argument.