### PR TITLE
Fixed callback call to assume a standard Node JS callback function

### DIFF
--- a/index.js
+++ b/index.js
@@ -331,7 +331,7 @@ NodeID3.prototype.create = function(tags, fn) {
     frames[0].writeUInt8(size[3], 9)
 
     if(fn && typeof fn === 'function') {
-        fn(Buffer.concat(frames))
+        fn(null, Buffer.concat(frames))
     } else {
         return Buffer.concat(frames)
     }


### PR DESCRIPTION
Fixed callback call at `create` function to assume a standard Node JS callback function: `(err, result) => ... `