### PR TITLE
Add synchronised lyrics support (SYLT frame)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.2.4] - 2022-11-09
+- Add synchronised lyrics (SYLT frame)
+
 ## [0.2.3] - 2021-04-30
 - Don't change APIC mime type on read
 - Fix unsynchronisation implementation

--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ unsynchronisedLyrics: {
   language: "eng",
   text: "lyrics"
 }
+// See documentation for more details.
+synchronisedLyrics: [{
+  language: "eng",
+  timeStampFormat: 2, // Absolute milliseconds
+  contentType: 1, // Lyrics
+  shortText: "Content descriptor",
+  synchronisedText: [{
+    text: "part 1",
+    timeStamp: 0
+  }, {
+    text: "part 2",
+    timeStamp: 1000
+  }]
+}]
 userDefinedText: [{
   description: "txxx name",
   value: "TXXX value text"
@@ -287,6 +301,7 @@ year:                 "TYER"
 comment:              "COMM"
 image:                "APIC"
 unsynchronisedLyrics  "USLT"
+synchronisedLyrics    "SYLT"
 userDefinedText       "TXXX"
 popularimeter         "POPM"
 private               "PRIV"

--- a/index.d.ts
+++ b/index.d.ts
@@ -255,7 +255,46 @@ declare module "node-id3" {
          unsynchronisedLyrics?: {
             language: string,
             text: string
-         }
+         },
+         /**
+          * SYLT frames
+          *
+          * @see {@link https://id3.org/d3v2.3.0 4.10. Synchronised lyrics/text}
+          */
+         synchronisedLyrics?: Array<{
+            /**
+             * 3 letter ISO 639-2 language code, for example: eng
+             * @see {@link https://id3.org/ISO%20639-2 ISO 639-2}
+             */
+            language: string,
+            /**
+             * Absolute time:
+             * - 1: MPEG frames unit
+             * - 2: milliseconds unit
+             */
+            timeStampFormat: number,
+            /**
+             * - 0: other
+             * - 1: lyrics
+             * - 2: text transcription
+             * - 3: movement/part name (e.g. "Adagio")
+             * - 4: events (e.g. "Don Quijote enters the stage")
+             * - 5: chord (e.g. "Bb F Fsus")
+             * - 6: is trivia/'pop up' information
+             */
+            contentType: number,
+            /**
+             * Content descriptor
+             */
+            shortText?: string,
+            synchronisedText: Array<{
+               text: string,
+               /**
+                * Absolute time in unit according to `timeStampFormat`.
+                */
+               timeStamp: number
+            }>
+         }>,
          userDefinedText?: [{
             description: string,
             value: string

--- a/src/ID3Definitions.js
+++ b/src/ID3Definitions.js
@@ -86,6 +86,7 @@ const FRAME_IDENTIFIERS = {
         comment:                "COMM",
         image:                  "APIC",
         unsynchronisedLyrics:   "USLT",
+        synchronisedLyrics:     "SYLT",
         userDefinedText:        "TXXX",
         popularimeter:          "POPM",
         private:                "PRIV",
@@ -139,6 +140,9 @@ const ID3_FRAME_OPTIONS = {
         },
         "USLT": {
             multiple: false
+        },
+        "SYLT": {
+            multiple: true
         },
         "COMM": {
             multiple: false /* change in 1.0 */

--- a/src/ID3Frames.js
+++ b/src/ID3Frames.js
@@ -164,8 +164,8 @@ module.exports.USLT = {
 
 module.exports.SYLT = {
     create: (data) => {
-        if(!data) {
-            return null
+        if(!(data instanceof Array)) {
+            data = [data]
         }
 
         const encoding = 1; // 16 bit unicode

--- a/test/test.js
+++ b/test/test.js
@@ -183,6 +183,29 @@ describe('NodeID3', function () {
             ), 0)
         })
 
+        it('create SYLT frame', function() {
+            let tags = {
+                synchronisedLyrics: [{
+                    language: "deu",
+                    timeStampFormat: 2, // Milliseconds
+                    contentType: 1, // Lyrics
+                    shortText: "Haiwsää#",
+                    synchronisedText: [{
+                        text: "askdh ashd olahs",
+                        timeStamp: 0
+                     }, {
+                        text: "elowz dlouaish dkajh",
+                        timeStamp: 1000
+                    }]
+                }]
+            }
+
+            assert.strictEqual(Buffer.compare(
+                NodeID3.create(tags),
+                Buffer.from('4944330300000000007c53594c54000000720000016465750201fffe48006100690077007300e400e40023000000fffe610073006b00640068002000610073006800640020006f006c00610068007300000000000000fffe65006c006f0077007a00200064006c006f0075006100690073006800200064006b0061006a0068000000000003e8', 'hex')
+            ), 0)
+        })
+
         it('create COMM frame', function() {
             const tags = {
                 comment: {
@@ -467,6 +490,27 @@ describe('NodeID3', function () {
             assert.deepStrictEqual(
                 NodeID3.read(frameBuf).unsynchronisedLyrics,
                 unsynchronisedLyrics
+            )
+        })
+
+        it('read SYLT frame', function() {
+            let frameBuf = Buffer.from('4944330300000000007c53594c54000000720000016465750201fffe48006100690077007300e400e40023000000fffe610073006b00640068002000610073006800640020006f006c00610068007300000000000000fffe65006c006f0077007a00200064006c006f0075006100690073006800200064006b0061006a0068000000000003e8', 'hex')
+            const synchronisedLyrics = [{
+                language: "deu",
+                timeStampFormat: 2, // Milliseconds
+                contentType: 1, // Lyrics
+                shortText: "Haiwsää#",
+                synchronisedText: [{
+                    text: "askdh ashd olahs",
+                    timeStamp: 0
+                    }, {
+                    text: "elowz dlouaish dkajh",
+                    timeStamp: 1000
+                }]
+            }]
+            assert.deepStrictEqual(
+                NodeID3.read(frameBuf).synchronisedLyrics,
+                synchronisedLyrics
             )
         })
 


### PR DESCRIPTION
## Changes

Use the same coding conventions as the rest of the code.
No other changes.
See https://id3.org/d3v2.3.0 for documentation of synchronized lyrics.
Use jsdoc for interface and type documentation, tested with VSCode.
Update README and CHANGELOG.

## Value vs array in create

As the SYLT frame can have multiple values (for different languages), the `multiple` option is set to true.  However unlike the other frames with the `multiple` option set to true, which can accept either a single value or an array, the `synchronisedLyrics` property is always an array.
I thought I like it because this is symmetric with the read which always return an array. However, I realise that this is inconsistent with the other `multiple` frames, and we might prefer consistency other better correctness.

I pushed a commit to change it for consistency.

## Timestamp vs Time stamp

Both one word and two words are accepted for time stamp. So for the symbols we could use either `timestamp` or `timeStamp`. 
In the id3 documentation both are used. 
But in https://id3.org/id3v2.4.0-frames 4.9 Synchronised lyrics/text it is written **time stamp format** as two words. Which is why I went for `timeStamp` in the symbol names.

## Time stamp format and content type values

The accepted values are documented, however, we could also provide enum value as part of the interface, which is a bit nicer.

```ts
    synchronisedLyrics: {
        // ...
        timeStampFormat: SynchronisedLyrics.TimeStampFormat.milliseconds
        contentType: SynchronisedLyrics.ContentType.lyrics
    }
```

This is open for extensions as if another value needs to be used, it still can be set.

Let me know if you wish to provide these I can add them.