### PR TITLE
Add tag constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ unsynchronisedLyrics: {
   language: "eng",
   text: "lyrics"
 }
-// See documentation for more details.
+// See https://id3.org/ documentation for more details.
 synchronisedLyrics: [{
   language: "eng",
-  timeStampFormat: 2, // Absolute milliseconds
-  contentType: 1, // Lyrics
+  timeStampFormat: Constants.TimeStampFormat.MILLISECONDS,
+  contentType: Constants.SynchronisedLyrics.ContentType.LYRICS,
   shortText: "Content descriptor",
   synchronisedText: [{
     text: "part 1",

--- a/README.md
+++ b/README.md
@@ -213,8 +213,7 @@ userDefinedText: [{
 image: {
   mime: "image/png",
   type: {
-    id: 3,
-    name: "front cover
+    id: Constants.AttachedPicture.PictureType.FRONT_COVER
   }, // See https://en.wikipedia.org/wiki/ID3#ID3v2_embedded_image_extension
   description: "image description",
   imageBuffer: (file buffer)

--- a/index.d.ts
+++ b/index.d.ts
@@ -257,7 +257,7 @@ declare module "node-id3" {
             text: string
          },
          /**
-          * SYLT frames
+          * `SYLT` tag frames
           *
           * @see {@link https://id3.org/d3v2.3.0 4.10. Synchronised lyrics/text}
           */
@@ -268,19 +268,12 @@ declare module "node-id3" {
              */
             language: string,
             /**
-             * Absolute time:
-             * - 1: MPEG frames unit
-             * - 2: milliseconds unit
+             * Absolute time unit:
+             * {@link Constants.TimeStampFormat}
              */
             timeStampFormat: number,
             /**
-             * - 0: other
-             * - 1: lyrics
-             * - 2: text transcription
-             * - 3: movement/part name (e.g. "Adagio")
-             * - 4: events (e.g. "Don Quijote enters the stage")
-             * - 5: chord (e.g. "Bb F Fsus")
-             * - 6: is trivia/'pop up' information
+             * {@link Constants.SynchronisedLyrics.ContentType}
              */
             contentType: number,
             /**
@@ -375,6 +368,75 @@ declare module "node-id3" {
             url: string
          }>,
          raw?: Tags
+      }
+      /**
+       * Documented constants used in tag frames.
+       *
+       * @see {@link https://id3.org/} for more information.
+       */
+      export const Constants: {
+         /**
+          * Absolute time unit used by:
+          * - Event timing codes (`ETCO` tag frame)
+          * - Synchronised tempo codes (`SYTC` tag frame)
+          * - Synchronised lyrics/text (`SYLT` tag frame)
+          * - Position synchronisation frame (`POSS` tag frame))
+          */
+         TimeStampFormat: {
+            MPEG_FRAMES: 1,
+            MILLISECONDS: 2
+         },
+         /**
+          * `SYLT` tag frame
+          */
+         SynchronisedLyrics: {
+               ContentType: {
+                  OTHER: 0x00,
+                  LYRICS: 0x01,
+                  TEXT_TRANSCRIPTION: 0x02,
+                  MOVEMENT_OR_PART_NAME: 0x03,
+                  EVENTS: 0x04,
+                  CHORD: 0x05,
+                  TRIVIA_OR_POP_UP_INFORMATION: 0x06
+               }
+         },
+         /**
+          * `APIC` tag frame
+          */
+         AttachedPicture: {
+            PictureType: {
+               OTHER: 0,
+               /**
+                * 32x32 pixels (PNG only)
+                */
+               FILE_ICON: 0x01,
+               OTHER_FILE_ICON: 0x02,
+               FRONT_COVER: 0x03,
+               BACK_COVER: 0x04,
+               LEAFLET_PAGE: 0x05,
+               /**
+                * Label side of CD
+                */
+               MEDIA: 0x06
+               /**
+                * Lead artist/lead performer/soloist
+                */,
+               LEAD_ARTIST: 0x07,
+               ARTIST_OR_PERFORMER: 0x08,
+               CONDUCTOR: 0x09,
+               BAND_OR_ORCHESTRA: 0x0A,
+               COMPOSER: 0x0B,
+               LYRICIST_OR_TEXT_WRITER: 0x0C,
+               RECORDING_LOCATION: 0x0D,
+               DURING_RECORDING: 0x0E,
+               DURING_PERFORMANCE: 0x0F,
+               MOVIE_OR_VIDEO_SCREEN_CAPTURE: 0x10,
+               A_BRIGHT_COLOURED_FISH: 0x11,
+               ILLUSTRATION: 0x12,
+               BAND_OR_ARTIST_LOGOTYPE: 0x13,
+               PUBLISHER_OR_STUDIO_LOGOTYPE: 0x14
+            }
+         }
       }
       export function write(tags: Tags, filebuffer: Buffer): Buffer
       export function write(tags: Tags, filebuffer: Buffer, fun: (err: null, buffer: Buffer) => void): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -399,18 +399,74 @@ declare module "node-id3" {
             MILLISECONDS: 2
          },
          /**
+          * `ETCO` tag frame
+          */
+         EventTimingCodes: {
+            EventType: {
+               /**
+                * Padding has no meaning
+                */
+               PADDING: 0x00,
+               END_OF_INITIAL_SILENCE: 0x01,
+               INTRO_START: 0x02,
+               MAINPART_START: 0x03,
+               OUTRO_START: 0x04,
+               OUTRO_END: 0x05,
+               VERSE_START: 0x06,
+               REFRAIN_START: 0x07,
+               INTERLUDE_START: 0x08,
+               THEME_START: 0x09,
+               VARIATION_START: 0x0A,
+               KEY_CHANGE: 0x0B,
+               TIME_CHANGE: 0x0C,
+               /**
+                * (Snap, Crackle & Pop)
+                */
+               MOMENTARY_UNWANTED_NOISE: 0x0D,
+               SUSTAINED_NOISE: 0x0E,
+               SUSTAINED_NOISE_END: 0x0F,
+               INTRO_END: 0x10,
+               MAINPART_END: 0x11,
+               VERSE_END: 0x12,
+               REFRAIN_END: 0x013,
+               THEME_END: 0x14,
+               /**
+                * $15-$DF reserved for future use
+                */
+               RESERVED_1: 0x15,
+               /**
+                * $E0-$EF not predefined sync 0-F
+                */
+               NOT_PREDEFINED_SYNC: 0xE0,
+               /**
+                * $F0-$FC reserved for future use
+                */
+               RESERVED_2: 0xF0,
+               /**
+                * Start of silence
+                */
+               AUDIO_END: 0xFD,
+               AUDIO_FILE_ENDS: 0xFE,
+               /**
+                * one more byte of events follows (all the following bytes with
+                * the value $FF have the same function)
+                */
+               ONE_MORE_BYTE_FOLLOWS: 0xFF
+            }
+         },
+         /**
           * `SYLT` tag frame
           */
          SynchronisedLyrics: {
-               ContentType: {
-                  OTHER: 0x00,
-                  LYRICS: 0x01,
-                  TEXT_TRANSCRIPTION: 0x02,
-                  MOVEMENT_OR_PART_NAME: 0x03,
-                  EVENTS: 0x04,
-                  CHORD: 0x05,
-                  TRIVIA_OR_POP_UP_INFORMATION: 0x06
-               }
+            ContentType: {
+               OTHER: 0x00,
+               LYRICS: 0x01,
+               TEXT_TRANSCRIPTION: 0x02,
+               MOVEMENT_OR_PART_NAME: 0x03,
+               EVENTS: 0x04,
+               CHORD: 0x05,
+               TRIVIA_OR_POP_UP_INFORMATION: 0x06
+            }
          },
          /**
           * `APIC` tag frame
@@ -447,6 +503,22 @@ declare module "node-id3" {
                ILLUSTRATION: 0x12,
                BAND_OR_ARTIST_LOGOTYPE: 0x13,
                PUBLISHER_OR_STUDIO_LOGOTYPE: 0x14
+            }
+         },
+         /**
+          * `COMR` tag frame
+          */
+         CommercialFrame: {
+            ReceivedAs: {
+               OTHER: 0x00,
+               STANDARD_CD_ALBUM_WITH_OTHER_SONGS: 0x01,
+               COMPRESSED_AUDIO_ON_CD: 0x02,
+               FILE_OVER_THE_INTERNET: 0x03,
+               STREAM_OVER_THE_INTERNET: 0x04,
+               AS_NOTE_SHEETS: 0x05,
+               AS_NOTE_SHEETS_IN_A_BOOK_WITH_OTHER_SHEETS: 0x06,
+               MUSIC_ON_OTHER_MEDIA: 0x07,
+               NON_MUSICAL_MERCHANDISE: 0x08
             }
          }
       }

--- a/index.d.ts
+++ b/index.d.ts
@@ -292,14 +292,26 @@ declare module "node-id3" {
             description: string,
             value: string
          }]
+         /**
+          * `APIC` (attached picture) tag frames
+          *
+          * Filename or image data.
+          */
          image?: string | {
             mime: string
             /**
              * See https://en.wikipedia.org/wiki/ID3#ID3v2_embedded_image_extension
              */
             type: {
+               /**
+                * {@link Constants.AttachedPicture.PictureType }
+                */
                id: number,
-               name: string
+               /**
+                * @deprecated Provided as an information when a tag is read,
+                * unused when a tag is written.
+                */
+               name?: string
             },
             description: string,
             imageBuffer: Buffer,

--- a/index.js
+++ b/index.js
@@ -535,3 +535,5 @@ module.exports.Promise = {
         })
     }
 }
+
+module.exports.Constants = ID3Definitions.Constants

--- a/src/ID3Definitions.js
+++ b/src/ID3Definitions.js
@@ -227,6 +227,62 @@ const Constants = {
         MILLISECONDS: 2
     },
     /**
+     * `ETCO` tag frame
+     */
+    EventTimingCodes: {
+        EventType: {
+            /**
+             * Padding has no meaning
+             */
+            PADDING: 0x00,
+            END_OF_INITIAL_SILENCE: 0x01,
+            INTRO_START: 0x02,
+            MAINPART_START: 0x03,
+            OUTRO_START: 0x04,
+            OUTRO_END: 0x05,
+            VERSE_START: 0x06,
+            REFRAIN_START: 0x07,
+            INTERLUDE_START: 0x08,
+            THEME_START: 0x09,
+            VARIATION_START: 0x0A,
+            KEY_CHANGE: 0x0B,
+            TIME_CHANGE: 0x0C,
+            /**
+             * (Snap, Crackle & Pop)
+             */
+            MOMENTARY_UNWANTED_NOISE: 0x0D,
+            SUSTAINED_NOISE: 0x0E,
+            SUSTAINED_NOISE_END: 0x0F,
+            INTRO_END: 0x10,
+            MAINPART_END: 0x11,
+            VERSE_END: 0x12,
+            REFRAIN_END: 0x013,
+            THEME_END: 0x14,
+            /**
+             * $15-$DF reserved for future use
+             */
+            RESERVED_1: 0x15,
+            /**
+             * $E0-$EF not predefined sync 0-F
+             */
+            NOT_PREDEFINED_SYNC: 0xE0,
+            /**
+             * $F0-$FC reserved for future use
+             */
+            RESERVED_2: 0xF0,
+            /**
+             * Start of silence
+             */
+            AUDIO_END: 0xFD,
+            AUDIO_FILE_ENDS: 0xFE,
+            /**
+             * one more byte of events follows (all the following bytes with
+             * the value $FF have the same function)
+             */
+            ONE_MORE_BYTE_FOLLOWS: 0xFF
+        }
+    },
+    /**
      * `SYLT` tag frame
      */
     SynchronisedLyrics: {
@@ -275,6 +331,22 @@ const Constants = {
             ILLUSTRATION: 0x12,
             BAND_OR_ARTIST_LOGOTYPE: 0x13,
             PUBLISHER_OR_STUDIO_LOGOTYPE: 0x14
+        }
+    },
+    /**
+     * `COMR` tag frame
+     */
+    CommercialFrame: {
+        ReceivedAs: {
+            OTHER: 0x00,
+            STANDARD_CD_ALBUM_WITH_OTHER_SONGS: 0x01,
+            COMPRESSED_AUDIO_ON_CD: 0x02,
+            FILE_OVER_THE_INTERNET: 0x03,
+            STREAM_OVER_THE_INTERNET: 0x04,
+            AS_NOTE_SHEETS: 0x05,
+            AS_NOTE_SHEETS_IN_A_BOOK_WITH_OTHER_SHEETS: 0x06,
+            MUSIC_ON_OTHER_MEDIA: 0x07,
+            NON_MUSICAL_MERCHANDISE: 0x08
         }
     }
 }

--- a/src/ID3Definitions.js
+++ b/src/ID3Definitions.js
@@ -209,8 +209,79 @@ const ENCODINGS = [
     'ISO-8859-1', 'UTF-16', 'UTF-16BE', 'utf8'
 ]
 
+/**
+ * Documented constants used in tag frames.
+ *
+ * @see {@link https://id3.org/} for more information.
+ */
+const Constants = {
+    /**
+     * Absolute time unit used by:
+     * - Event timing codes (`ETCO` tag frame)
+     * - Synchronised tempo codes (`SYTC` tag frame)
+     * - Synchronised lyrics/text (`SYLT` tag frame)
+     * - Position synchronisation frame (`POSS` tag frame))
+     */
+    TimeStampFormat: {
+        MPEG_FRAMES: 1,
+        MILLISECONDS: 2
+    },
+    /**
+     * `SYLT` tag frame
+     */
+    SynchronisedLyrics: {
+        ContentType: {
+            OTHER: 0x00,
+            LYRICS: 0x01,
+            TEXT_TRANSCRIPTION: 0x02,
+            MOVEMENT_OR_PART_NAME: 0x03,
+            EVENTS: 0x04,
+            CHORD: 0x05,
+            TRIVIA_OR_POP_UP_INFORMATION: 0x06
+        }
+    },
+    /**
+     * `APIC` tag frame
+     */
+     AttachedPicture: {
+        PictureType: {
+            OTHER: 0,
+            /**
+             * 32x32 pixels (PNG only)
+             */
+            FILE_ICON: 0x01,
+            OTHER_FILE_ICON: 0x02,
+            FRONT_COVER: 0x03,
+            BACK_COVER: 0x04,
+            LEAFLET_PAGE: 0x05,
+            /**
+             * Label side of CD
+             */
+            MEDIA: 0x06
+            /**
+             * Lead artist/lead performer/soloist
+             */,
+            LEAD_ARTIST: 0x07,
+            ARTIST_OR_PERFORMER: 0x08,
+            CONDUCTOR: 0x09,
+            BAND_OR_ORCHESTRA: 0x0A,
+            COMPOSER: 0x0B,
+            LYRICIST_OR_TEXT_WRITER: 0x0C,
+            RECORDING_LOCATION: 0x0D,
+            DURING_RECORDING: 0x0E,
+            DURING_PERFORMANCE: 0x0F,
+            MOVIE_OR_VIDEO_SCREEN_CAPTURE: 0x10,
+            A_BRIGHT_COLOURED_FISH: 0x11,
+            ILLUSTRATION: 0x12,
+            BAND_OR_ARTIST_LOGOTYPE: 0x13,
+            PUBLISHER_OR_STUDIO_LOGOTYPE: 0x14
+        }
+    }
+}
+
 module.exports.APIC_TYPES = APICTypes
 module.exports.ENCODINGS = ENCODINGS
 module.exports.FRAME_IDENTIFIERS = FRAME_IDENTIFIERS
 module.exports.FRAME_INTERNAL_IDENTIFIERS = FRAME_INTERNAL_IDENTIFIERS
 module.exports.ID3_FRAME_OPTIONS = ID3_FRAME_OPTIONS
+module.exports.Constants = Constants

--- a/src/ID3Frames.js
+++ b/src/ID3Frames.js
@@ -65,6 +65,11 @@ module.exports.APIC = {
                 }
             }
 
+            const Constants = ID3Definitions.Constants.AttachedPicture
+            const pictureType = data.type || {};
+            const pictureTypeId = pictureType.id === undefined
+                ? Constants.PictureType.FRONT_COVER : pictureType.id
+
             /*
              * Fix a bug in iTunes where the artwork is not recognized when the description is empty using UTF-16.
              * Instead, if the description is empty, use encoding 0x00 (ISO-8859-1).
@@ -74,7 +79,7 @@ module.exports.APIC = {
             return new ID3FrameBuilder("APIC")
               .appendStaticNumber(encoding, 1)
               .appendNullTerminatedValue(mime_type)
-              .appendStaticNumber(0x03, 1)
+              .appendStaticNumber(pictureTypeId, 1)
               .appendNullTerminatedValue(description, encoding)
               .appendStaticValue(data.imageBuffer)
               .getBuffer()

--- a/test/test.js
+++ b/test/test.js
@@ -131,7 +131,9 @@ describe('NodeID3', function () {
                     description: "asdf",
                     imageBuffer: Buffer.from('5B307836312C20307836322C20307836332C20307836345D', 'hex'),
                     mime: "image/jpeg",
-                    type: {id: 3, name: "front cover"}
+                    type: {
+                        id: NodeID3.Constants.AttachedPicture.FRONT_COVER
+                    }
                 }
             }
 

--- a/test/test.js
+++ b/test/test.js
@@ -184,11 +184,12 @@ describe('NodeID3', function () {
         })
 
         it('create SYLT frame', function() {
+            const Constants = NodeID3.Constants
             let tags = {
                 synchronisedLyrics: [{
                     language: "deu",
-                    timeStampFormat: 2, // Milliseconds
-                    contentType: 1, // Lyrics
+                    timeStampFormat: Constants.TimeStampFormat.MILLISECONDS,
+                    contentType: Constants.SynchronisedLyrics.ContentType.LYRICS,
                     shortText: "Haiwsää#",
                     synchronisedText: [{
                         text: "askdh ashd olahs",
@@ -495,10 +496,11 @@ describe('NodeID3', function () {
 
         it('read SYLT frame', function() {
             let frameBuf = Buffer.from('4944330300000000007c53594c54000000720000016465750201fffe48006100690077007300e400e40023000000fffe610073006b00640068002000610073006800640020006f006c00610068007300000000000000fffe65006c006f0077007a00200064006c006f0075006100690073006800200064006b0061006a0068000000000003e8', 'hex')
+            const Constants = NodeID3.Constants;
             const synchronisedLyrics = [{
                 language: "deu",
-                timeStampFormat: 2, // Milliseconds
-                contentType: 1, // Lyrics
+                timeStampFormat: Constants.TimeStampFormat.MILLISECONDS,
+                contentType: Constants.SynchronisedLyrics.ContentType.LYRICS,
                 shortText: "Haiwsää#",
                 synchronisedText: [{
                     text: "askdh ashd olahs",


### PR DESCRIPTION
## Context

This PR add tag numerical constants for frames that are currently supported by the library.

I have already defined constants for `ETCO` and `COMR` frames but did not realise they were not supported yet, so I did not include the definitions.
Also definitions for `TFLT` and `TMED` are a bit special, I did not include them in this PR.

I did not update the versioning yet, let me know if you want to do a release on this PR or not.

## Details

- use "Constants" as a namespace (not TagConstants as the tag prefix felt unnecessary we are in a tag library already), let me know if you feel that `TagConstants` would be preferred
- there is an unfortunate duplicate between the implementation file and the declaration file due to the fact that the implementation is Javascript and not Typescript
- use naming conventions widely used by the community, see for example
  https://google.github.io/styleguide/jsguide.html#naming
  https://developer.mozilla.org/en-US/docs/MDN/Community
  https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/
- handle APIC picture type in create
  -  handle the picture id in frame `create` instead of hardcoded value of 3
  - update the documentation
  - update the test

