### PR TITLE
Fix compression and reduce code complexity

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,29 +183,29 @@ function update(tags, filebuffer, options, fn) {
 
     const updateFn = (currentTags) => {
         currentTags = currentTags.raw || {}
-        Object.keys(rawTags).map((specName) => {
-            const options = ID3Util.getSpecOptions(specName, 3)
+        Object.keys(rawTags).map((frameIdentifier) => {
+            const options = ID3Util.getSpecOptions(frameIdentifier, 3)
             const cCompare = {}
-            if(options.multiple && currentTags[specName] && rawTags[specName]) {
+            if(options.multiple && currentTags[frameIdentifier] && rawTags[frameIdentifier]) {
                 if(options.updateCompareKey) {
-                    currentTags[specName].forEach((cTag, index) => {
+                    currentTags[frameIdentifier].forEach((cTag, index) => {
                         cCompare[cTag[options.updateCompareKey]] = index
                     })
 
                 }
-                if (!(rawTags[specName] instanceof Array)) {
-                    rawTags[specName] = [rawTags[specName]]
+                if (!(rawTags[frameIdentifier] instanceof Array)) {
+                    rawTags[frameIdentifier] = [rawTags[frameIdentifier]]
                 }
-                rawTags[specName].forEach((rTag) => {
+                rawTags[frameIdentifier].forEach((rTag) => {
                     const comparison = cCompare[rTag[options.updateCompareKey]]
                     if (comparison !== undefined) {
-                        currentTags[specName][comparison] = rTag
+                        currentTags[frameIdentifier][comparison] = rTag
                     } else {
-                        currentTags[specName].push(rTag)
+                        currentTags[frameIdentifier].push(rTag)
                     }
                 })
             } else {
-                currentTags[specName] = rawTags[specName]
+                currentTags[frameIdentifier] = rawTags[frameIdentifier]
             }
         })
         return currentTags

--- a/src/ID3Frames.js
+++ b/src/ID3Frames.js
@@ -7,12 +7,12 @@ const ID3Helpers = require('./ID3Helpers')
 const { isString } = require('./util')
 
 module.exports.GENERIC_TEXT = {
-    create: (specName, data) => {
-        if(!specName || !data) {
+    create: (frameIdentifier, data) => {
+        if(!frameIdentifier || !data) {
             return null
         }
 
-        return new ID3FrameBuilder(specName)
+        return new ID3FrameBuilder(frameIdentifier)
             .appendStaticNumber(0x01, 0x01)
             .appendStaticValue(data, null, 0x01)
             .getBuffer()
@@ -25,12 +25,12 @@ module.exports.GENERIC_TEXT = {
 }
 
 module.exports.GENERIC_URL = {
-    create: (specName, data) => {
-        if(!specName || !data) {
+    create: (frameIdentifier, data) => {
+        if(!frameIdentifier || !data) {
             return null
         }
 
-        return new ID3FrameBuilder(specName)
+        return new ID3FrameBuilder(frameIdentifier)
             .appendStaticValue(data)
             .getBuffer()
     },

--- a/src/ID3Helpers.js
+++ b/src/ID3Helpers.js
@@ -133,7 +133,7 @@ function getFramesFromID3Body(ID3FrameBody, ID3Version, options = {}) {
         }
         const bodyFrameBuffer = Buffer.alloc(bodyFrameSize)
         ID3FrameBody.copy(bodyFrameBuffer, 0, currentPosition + textframeHeaderSize + (frameHeaderFlags.dataLengthIndicator ? 4 : 0))
-        let frame = {
+        const frame = {
             name: specName,
             flags: frameHeaderFlags,
             body: frameHeaderFlags.unsynchronisation ? ID3Util.processUnsynchronisedBuffer(bodyFrameBuffer) : bodyFrameBuffer
@@ -162,7 +162,7 @@ function decompressFrame(frame) {
     * 2. else try if header is not stored (assume that all content is deflated "body")
     * 3. else try if inflation works if the header is omitted (implementation dependent)
     * */
-    let decompressedBody;
+    let decompressedBody
     try {
         decompressedBody = zlib.inflateSync(frame.body)
     } catch (e) {
@@ -206,7 +206,7 @@ function getTagsFromFrames(frames, ID3Version, options = {}) {
         }
 
         if(frame.flags.compression) {
-            let decompressedBody = decompressFrame(frame)
+            const decompressedBody = decompressFrame(frame)
             if(!decompressedBody) {
                 return
             }

--- a/src/ID3Util.js
+++ b/src/ID3Util.js
@@ -62,9 +62,9 @@ module.exports.bufferToDecodedString = function(buffer, encodingByte) {
     return iconv.decode(buffer, this.encodingFromStringOrByte(encodingByte)).replace(/\0/g, '')
 }
 
-module.exports.getSpecOptions = function(specName) {
-    if(ID3Definitions.ID3_FRAME_OPTIONS[specName]) {
-        return ID3Definitions.ID3_FRAME_OPTIONS[specName]
+module.exports.getSpecOptions = function(frameIdentifier) {
+    if(ID3Definitions.ID3_FRAME_OPTIONS[frameIdentifier]) {
+        return ID3Definitions.ID3_FRAME_OPTIONS[frameIdentifier]
     }
 
     return {}
@@ -195,7 +195,8 @@ module.exports.parseFrameHeaderFlags = function(header, ID3Version) {
             readOnly: !!(flagsFirstByte & 32),
             compression: !!(flagsSecondByte & 128),
             encryption: !!(flagsSecondByte & 64),
-            groupingIdentity: !!(flagsSecondByte & 32)
+            groupingIdentity: !!(flagsSecondByte & 32),
+            dataLengthIndicator: !!(flagsSecondByte & 128)
         }
     }
     if(ID3Version === 4) {

--- a/test/test.js
+++ b/test/test.js
@@ -824,6 +824,16 @@ describe('NodeID3', function () {
                 tags
             )
         })
+
+        it('compressed frame', function() {
+            const frameBuf = Buffer.from('4944330400000000001c5449543200000011000900000005789c6328492d2e0100045e01c1', 'hex')
+            const tags = { TIT2: 'test' }
+
+            assert.deepStrictEqual(
+                NodeID3.read(frameBuf).raw,
+                tags
+            )
+        })
     })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -826,11 +826,17 @@ describe('NodeID3', function () {
         })
 
         it('compressed frame', function() {
-            const frameBuf = Buffer.from('4944330400000000001c5449543200000011000900000005789c6328492d2e0100045e01c1', 'hex')
+            const frameBufV3 = Buffer.from('4944330300000000001c5449543200000011008000000005789c6328492d2e0100045e01c1', 'hex')
+            const frameBufV4 = Buffer.from('4944330400000000001c5449543200000011000900000005789c6328492d2e0100045e01c1', 'hex')
             const tags = { TIT2: 'test' }
 
             assert.deepStrictEqual(
-                NodeID3.read(frameBuf).raw,
+                NodeID3.read(frameBufV3).raw,
+                tags
+            )
+
+            assert.deepStrictEqual(
+                NodeID3.read(frameBufV4).raw,
                 tags
             )
         })


### PR DESCRIPTION
Compression was broken because the data length indicator was not passed to the frame body buffer but compression relies on it.