### PR TITLE
Add support for UFID (unique file identifier) frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ private: [{
   ownerIdentifier: "AbCSSS",
   data: Buffer.from([0x01, 0x02, 0x05])
 }],
+uniqueFileIdentifier: [{
+  ownerIdentifier: "owner-id-1",
+  identifier: Buffer.from("identifier-1")
+}], {
+  ownerIdentifier: "owner-id-2",
+  identifier: Buffer.from("identifier-2")
+},
 chapter: [{
   elementID: "Hey!", // THIS MUST BE UNIQUE!
   startTimeMs: 5000,
@@ -360,6 +367,7 @@ synchronisedLyrics    "SYLT"
 userDefinedText       "TXXX"
 popularimeter         "POPM"
 private               "PRIV"
+uniqueFileIdentifier  "UFID"
 chapter               "CHAP"
 tableOfContents       "CTOC"
 commercialUrl         "WCOM"

--- a/index.d.ts
+++ b/index.d.ts
@@ -382,6 +382,33 @@ declare module "node-id3" {
             ownerIdentifier: string,
             data: string
          }],
+         /**
+          * This frame's purpose is to be able to identify the audio file in a
+          * database that may contain more information relevant to the content.
+          * Since standardisation of such a database is beyond this document,
+          * all frames begin with a null-terminated string with a URL
+          * containing an email address, or a link to a location where an email
+          * address can be found, that belongs to the organisation responsible
+          * for this specific database implementation. Questions regarding the
+          * database should be sent to the indicated email address. The URL
+          * should not be used for the actual database queries. The string
+          * "http://www.id3.org/dummy/ufid.html" should be used for tests.
+          * Software that isn't told otherwise may safely remove such frames.
+          *
+          * There may be more than one "UFID" frame in a tag, but only one with
+          * the same `ownerIdentifier`.
+          */
+         uniqueFileIdentifier?: Array<{
+            /**
+             * Must be non-empty.
+             */
+            ownerIdentifier: string,
+            /**
+             * Up to 64 bytes of binary data.
+             * Providing more data will result in an undefined behaviour.
+             */
+            identifier: Buffer
+         }>,
          chapter?: Array<{
             elementID: string,
             endTimeMs: number,

--- a/src/ID3Definitions.js
+++ b/src/ID3Definitions.js
@@ -102,7 +102,8 @@ const FRAME_IDENTIFIERS = {
         paymentUrl:             "WPAY",
         publisherUrl:           "WPUB",
         eventTimingCodes:       "ETCO",
-        commercialFrame:        "COMR"
+        commercialFrame:        "COMR",
+        uniqueFileIdentifier:   "UFID"
     },
     /**
      * v4 removes some text frames compared to v3: TDAT, TIME, TRDA, TSIZ, TYER
@@ -245,6 +246,9 @@ const ID3_FRAME_OPTIONS = {
         multiple: false
     },
     "COMR": {
+        multiple: true
+    },
+    "UFID": {
         multiple: true
     }
 }

--- a/src/ID3Frames.js
+++ b/src/ID3Frames.js
@@ -280,6 +280,29 @@ module.exports.PRIV = {
     }
 }
 
+module.exports.UFID = {
+    create: (data) => {
+        if (!(data instanceof Array)) {
+            data = [data]
+        }
+
+        return Buffer.concat(data.map(ufid => new ID3FrameBuilder("UFID")
+            .appendNullTerminatedValue(ufid.ownerIdentifier)
+            .appendStaticValue(
+                ufid.identifier instanceof Buffer ?
+                ufid.identifier : Buffer.from(ufid.identifier, "utf8")
+            )
+            .getBuffer()))
+    },
+    read: (buffer) => {
+        const reader = new ID3FrameReader(buffer)
+        return {
+            ownerIdentifier: reader.consumeNullTerminatedValue('string'),
+            identifier: reader.consumeStaticValue()
+        }
+    }
+}
+
 module.exports.CHAP = {
     create: (data) => {
         if (!(data instanceof Array)) {

--- a/test/test.js
+++ b/test/test.js
@@ -258,6 +258,21 @@ describe('NodeID3', function () {
             )
         })
 
+        it("create UFID frame", function () {
+            const frameBuf = Buffer.from('49443303000000000042554649440000001700006f776e65722d69642d31006964656e7469666965722d31554649440000001700006f776e65722d69642d32006964656e7469666965722d32', 'hex')
+            const tags = {
+                UFID: [{
+                    ownerIdentifier: "owner-id-1",
+                    identifier: Buffer.from("identifier-1")
+                }, {
+                    ownerIdentifier: "owner-id-2",
+                    identifier: Buffer.from("identifier-2")
+                }],
+            }
+
+            assert.deepStrictEqual(NodeID3.create(tags), frameBuf)
+        })
+
         it('create CHAP frame', function() {
             const frameBuf = Buffer.from('494433030000000000534348415000000049000048657921000000138800001F400000007B000001C8544954320000000F000001FFFE6100620063006400650066005450453100000011000001FFFE61006B0073006800640061007300', 'hex')
             const tags = { CHAP: [{
@@ -639,6 +654,22 @@ describe('NodeID3', function () {
             assert.deepStrictEqual(
                 NodeID3.read(frameBuf).private,
                 priv
+            )
+        })
+
+        it("read UFID frame", function () {
+            const frameBuf = Buffer.from('49443303000000000042554649440000001700006f776e65722d69642d31006964656e7469666965722d31554649440000001700006f776e65722d69642d32006964656e7469666965722d32', 'hex')
+            const ufid = [{
+                ownerIdentifier: "owner-id-1",
+                identifier: Buffer.from("identifier-1")
+            }, {
+                ownerIdentifier: "owner-id-2",
+                identifier: Buffer.from("identifier-2")
+            }]
+
+            assert.deepStrictEqual(
+                NodeID3.read(frameBuf).uniqueFileIdentifier,
+                ufid
             )
         })
 


### PR DESCRIPTION
See https://id3.org/id3v2.4.0-frames (Section 4.1) for details.

This frame is very similar to the `PRIV` frame, however the implementation has been changed slightly.
Since the `identifier` is expected to be binary data, unlike the `PRIV` frame, the implementation does not accept a string. This is left to user to encode a string.
The `PRIV` frame implementation causes two issues:
- the encoding used to encode the string (currently utf8) is not documented and the user does not know how to decode the string received as a Buffer when read
- the create and read API are asymmetric

Like other ID3 constraints, this implementation does not try to verify or apply any constraints on the data, for example the fact that owner identifiers should be unique or that the size of the identifier binary data should not be more than 64 bytes.

Note in the test and the documentation the usage of more expressive example data than in the other frames.