### PR TITLE
Move ID3 frame code into its own class

### DIFF
--- a/src/ID3Frame.js
+++ b/src/ID3Frame.js
@@ -19,6 +19,9 @@ class ID3Frame {
         }
         const frameHeaderBuffer = frameBuffer.subarray(0, frameHeaderSize)
         const frameHeader = ID3FrameHeader.createFromBuffer(frameHeaderBuffer, version)
+        if(frameHeader.flags.encryption) {
+            return null
+        }
 
         const frameBodyOffset = frameHeader.flags.dataLengthIndicator ? 4 : 0
         const frameBodyStart = frameHeaderSize + frameBodyOffset

--- a/src/ID3Frame.js
+++ b/src/ID3Frame.js
@@ -1,0 +1,106 @@
+const zlib = require('zlib')
+const ID3FrameHeader = require('./ID3FrameHeader')
+const ID3Frames = require('./ID3Frames')
+
+class ID3Frame {
+    constructor(identifier, value, flags = {}) {
+        this.identifier = identifier
+        this.value = value
+        this.dataLengthIndicator = 0
+        this.flags = flags
+    }
+
+    static createFromBuffer(frameBuffer, version) {
+        const frameHeaderSize = ID3FrameHeader.getSizeByVersion(version)
+        // Specification requirement
+        if(frameBuffer < frameHeaderSize + 1) {
+            return null
+        }
+        const frameHeaderBuffer = frameBuffer.subarray(0, frameHeaderSize)
+        const frameHeader = ID3FrameHeader.createFromBuffer(frameHeaderBuffer, version)
+
+        const frameBodyOffset = frameHeader.flags.dataLengthIndicator ? 4 : 0
+        const frameBodyStart = frameHeaderSize + frameBodyOffset
+        let frameBody = frameBuffer.subarray(frameBodyStart, frameBodyStart + frameHeader.frameSize - frameBodyOffset)
+        if(frameHeader.flags.unsynchronisation) {
+            // This method should stay in ID3Util for now because it's also used in the Tag's header which we don't have a class for.
+            frameBody = ID3Util.processUnsynchronisedBuffer(frameBody)
+        }
+        if(frameHeader.flags.dataLengthIndicator) {
+            this.dataLengthIndicator = frameBuffer.readInt32BE(frameHeaderSize)
+        }
+        if(frameHeader.flags.compression) {
+            const uncompressedFrameBody = this.decompressBodyBuffer(frameBody, this.dataLengthIndicator)
+            if(!uncompressedFrameBody) {
+                return null
+            }
+            frameBody = uncompressedFrameBody
+        }
+
+        let value = null
+        if(ID3Frames[frameHeader.identifier]) {
+            value = ID3Frames[frameHeader.identifier].read(frameBody, version)
+        } else if(frameHeader.identifier.startsWith('T')) {
+            value = ID3Frames.GENERIC_TEXT.read(frameBody, version)
+        } else if(frameHeader.identifier.startsWith('W')) {
+            value = ID3Frames.GENERIC_URL.read(frameBody, version)
+        } else {
+            // Unknown frames are not supported currently.
+            return null
+        }
+
+        return new ID3Frame(frameHeader.identifier, value, frameHeader.flags)
+    }
+
+    getBuffer() {
+        if(ID3Frames[this.identifier]) {
+            return ID3Frames[this.identifier].create(this.value)
+        }
+        if(this.identifier.startsWith('T')) {
+            return ID3Frames.GENERIC_TEXT.create(this.value)
+        }
+        if(this.identifier.startsWith('W')) {
+            return ID3Frames.GENERIC_URL.create(this.value)
+        }
+
+        return null
+    }
+
+    getValue() {
+        return this.value
+    }
+
+    static decompressBodyBuffer(bodyBuffer, dataLengthIndicator) {
+        if(bodyBuffer.length < 5 || dataLengthIndicator === undefined) {
+            return null
+        }
+
+        /*
+        * ID3 spec defines that compression is stored in ZLIB format, but doesn't specify if header is present or not.
+        * ZLIB has a 2-byte header.
+        * 1. try if header + body decompression
+        * 2. else try if header is not stored (assume that all content is deflated "body")
+        * 3. else try if inflation works if the header is omitted (implementation dependent)
+        * */
+        let decompressedBody
+        try {
+            decompressedBody = zlib.inflateSync(bodyBuffer)
+        } catch (e) {
+            try {
+                decompressedBody = zlib.inflateRawSync(bodyBuffer)
+            } catch (e) {
+                try {
+                    decompressedBody = zlib.inflateRawSync(bodyBuffer.subarray(2))
+                } catch (e) {
+                    return null
+                }
+            }
+        }
+        if(decompressedBody.length !== dataLengthIndicator) {
+            return null
+        }
+        return decompressedBody
+    }
+}
+
+module.exports = ID3Frame

--- a/src/ID3Frame.js
+++ b/src/ID3Frame.js
@@ -1,6 +1,7 @@
 const zlib = require('zlib')
 const ID3FrameHeader = require('./ID3FrameHeader')
 const ID3Frames = require('./ID3Frames')
+const ID3Util = require('./ID3Util')
 
 class ID3Frame {
     constructor(identifier, value, flags = {}) {

--- a/src/ID3FrameHeader.js
+++ b/src/ID3FrameHeader.js
@@ -1,0 +1,88 @@
+const ID3Util = require('./ID3Util')
+const ID3Definitions = require("./ID3Definitions")
+
+class ID3FrameHeader {
+    constructor(identifier, frameSize, flags = {}) {
+        this.identifier = identifier
+        this.frameSize = frameSize
+        this.flags = flags
+    }
+
+    static createFromBuffer(headerBuffer, version) {
+        const identifierSize = (version === 2) ? 3 : 4
+        let identifier = headerBuffer.toString('utf8', 0, identifierSize)
+        const frameSize = this.getFrameSizeFromBuffer(headerBuffer, version)
+        const flags = this.getFlagsFromBytes(headerBuffer[8], headerBuffer[9], version)
+
+        // Try to convert identifier for older versions
+        if(version === 2) {
+            const alias = ID3Definitions.FRAME_INTERNAL_IDENTIFIERS.v2[identifier]
+            if(alias) {
+                frameIdentifier = ID3Definitions.FRAME_IDENTIFIERS.v3[alias]
+            }
+        }
+
+        return new ID3FrameHeader(identifier, frameSize, flags)
+    }
+
+    getBuffer() {
+        const buffer = Buffer.alloc(10)
+        buffer.write(this.identifier, 0)
+        buffer.writeUInt32BE(this.frameSize, 4)
+        return buffer
+    }
+
+    static getSizeByVersion(version) {
+        return (version === 2) ? 6 : 10
+    }
+
+    static getFrameSizeFromBuffer(headerBuffer, version) {
+        const isDecoded = version === 4
+        let bytes
+        if(version === 2) {
+            bytes = [headerBuffer[3], headerBuffer[4], headerBuffer[5]]
+        } else {
+            bytes = [headerBuffer[4], headerBuffer[5], headerBuffer[6], headerBuffer[7]]
+        }
+        if(isDecoded) {
+            return ID3Util.decodeSize(Buffer.from(bytes))
+        }
+
+        return Buffer.from(bytes).readUIntBE(0, bytes.length)
+    }
+
+    static getFlagsFromBytes(statusFlag, encodingFlag, version) {
+        if(version === 2) {
+            return {}
+        }
+
+        if(version === 3) {
+            return {
+                tagAlterPreservation: !!(statusFlag & 128),
+                fileAlterPreservation: !!(statusFlag & 64),
+                readOnly: !!(statusFlag & 32),
+                compression: !!(encodingFlag & 128),
+                encryption: !!(encodingFlag & 64),
+                groupingIdentity: !!(encodingFlag & 32),
+                dataLengthIndicator: !!(encodingFlag & 128)
+            }
+        }
+
+        if(version === 4) {
+            return {
+                tagAlterPreservation: !!(statusFlag & 64),
+                fileAlterPreservation: !!(statusFlag & 32),
+                readOnly: !!(statusFlag & 16),
+                groupingIdentity: !!(encodingFlag & 64),
+                compression: !!(encodingFlag & 8),
+                encryption: !!(encodingFlag & 4),
+                unsynchronisation: !!(encodingFlag & 2),
+                dataLengthIndicator: !!(encodingFlag & 1)
+            }
+        }
+
+        return {}
+    }
+}
+
+module.exports = ID3FrameHeader

--- a/src/ID3FrameHeader.js
+++ b/src/ID3FrameHeader.js
@@ -18,7 +18,7 @@ class ID3FrameHeader {
         if(version === 2) {
             const alias = ID3Definitions.FRAME_INTERNAL_IDENTIFIERS.v2[identifier]
             if(alias) {
-                frameIdentifier = ID3Definitions.FRAME_IDENTIFIERS.v3[alias]
+                identifier = ID3Definitions.FRAME_IDENTIFIERS.v3[alias]
             }
         }
 

--- a/src/ID3FrameHeader.js
+++ b/src/ID3FrameHeader.js
@@ -2,87 +2,96 @@ const ID3Util = require('./ID3Util')
 const ID3Definitions = require("./ID3Definitions")
 
 class ID3FrameHeader {
-    constructor(identifier, frameSize, flags = {}) {
+    constructor(identifier, bodySize, flags = {}) {
         this.identifier = identifier
-        this.frameSize = frameSize
+        this.bodySize = bodySize
         this.flags = flags
-    }
-
-    static createFromBuffer(headerBuffer, version) {
-        const identifierSize = (version === 2) ? 3 : 4
-        let identifier = headerBuffer.toString('utf8', 0, identifierSize)
-        const frameSize = this.getFrameSizeFromBuffer(headerBuffer, version)
-        const flags = this.getFlagsFromBytes(headerBuffer[8], headerBuffer[9], version)
-
-        // Try to convert identifier for older versions
-        if(version === 2) {
-            const alias = ID3Definitions.FRAME_INTERNAL_IDENTIFIERS.v2[identifier]
-            if(alias) {
-                identifier = ID3Definitions.FRAME_IDENTIFIERS.v3[alias]
-            }
-        }
-
-        return new ID3FrameHeader(identifier, frameSize, flags)
     }
 
     getBuffer() {
         const buffer = Buffer.alloc(10)
         buffer.write(this.identifier, 0)
-        buffer.writeUInt32BE(this.frameSize, 4)
+        buffer.writeUInt32BE(this.bodySize, 4)
         return buffer
     }
 
-    static getSizeByVersion(version) {
-        return (version === 2) ? 6 : 10
-    }
-
-    static getFrameSizeFromBuffer(headerBuffer, version) {
-        const isDecoded = version === 4
-        let bytes
-        if(version === 2) {
-            bytes = [headerBuffer[3], headerBuffer[4], headerBuffer[5]]
-        } else {
-            bytes = [headerBuffer[4], headerBuffer[5], headerBuffer[6], headerBuffer[7]]
-        }
-        if(isDecoded) {
-            return ID3Util.decodeSize(Buffer.from(bytes))
-        }
-
-        return Buffer.from(bytes).readUIntBE(0, bytes.length)
-    }
-
-    static getFlagsFromBytes(statusFlag, encodingFlag, version) {
-        if(version === 2) {
-            return {}
-        }
-
-        if(version === 3) {
-            return {
-                tagAlterPreservation: !!(statusFlag & 128),
-                fileAlterPreservation: !!(statusFlag & 64),
-                readOnly: !!(statusFlag & 32),
-                compression: !!(encodingFlag & 128),
-                encryption: !!(encodingFlag & 64),
-                groupingIdentity: !!(encodingFlag & 32),
-                dataLengthIndicator: !!(encodingFlag & 128)
-            }
-        }
-
-        if(version === 4) {
-            return {
-                tagAlterPreservation: !!(statusFlag & 64),
-                fileAlterPreservation: !!(statusFlag & 32),
-                readOnly: !!(statusFlag & 16),
-                groupingIdentity: !!(encodingFlag & 64),
-                compression: !!(encodingFlag & 8),
-                encryption: !!(encodingFlag & 4),
-                unsynchronisation: !!(encodingFlag & 2),
-                dataLengthIndicator: !!(encodingFlag & 1)
-            }
-        }
-
-        return {}
-    }
 }
 
-module.exports = ID3FrameHeader
+function createFromBuffer(headerBuffer, version) {
+    const identifierSize = (version === 2) ? 3 : 4
+    let identifier = headerBuffer.toString('utf8', 0, identifierSize)
+    const frameSize = getBodySize(headerBuffer, version)
+    const flags = extractFlags(headerBuffer[8], headerBuffer[9], version)
+
+    // Try to convert identifier for older versions
+    if(version === 2) {
+        const alias = ID3Definitions.FRAME_INTERNAL_IDENTIFIERS.v2[identifier]
+        if(alias) {
+            identifier = ID3Definitions.FRAME_IDENTIFIERS.v3[alias]
+        }
+    }
+
+    return new ID3FrameHeader(identifier, frameSize, flags)
+}
+
+function extractFlags(statusFlag, encodingFlag, version) {
+    if(version === 2) {
+        return {}
+    }
+
+    if(version === 3) {
+        return {
+            tagAlterPreservation: !!(statusFlag & 128),
+            fileAlterPreservation: !!(statusFlag & 64),
+            readOnly: !!(statusFlag & 32),
+            compression: !!(encodingFlag & 128),
+            encryption: !!(encodingFlag & 64),
+            groupingIdentity: !!(encodingFlag & 32),
+            dataLengthIndicator: !!(encodingFlag & 128)
+        }
+    }
+
+    if(version === 4) {
+        return {
+            tagAlterPreservation: !!(statusFlag & 64),
+            fileAlterPreservation: !!(statusFlag & 32),
+            readOnly: !!(statusFlag & 16),
+            groupingIdentity: !!(encodingFlag & 64),
+            compression: !!(encodingFlag & 8),
+            encryption: !!(encodingFlag & 4),
+            unsynchronisation: !!(encodingFlag & 2),
+            dataLengthIndicator: !!(encodingFlag & 1)
+        }
+    }
+
+    return {}
+}
+
+function getHeaderSize(version) {
+    return (version === 2) ? 6 : 10
+}
+
+function getBodySize(headerBuffer, version) {
+    const isDecoded = version === 4
+    let bytes
+    if(version === 2) {
+        bytes = [headerBuffer[3], headerBuffer[4], headerBuffer[5]]
+    } else {
+        bytes = [headerBuffer[4], headerBuffer[5], headerBuffer[6], headerBuffer[7]]
+    }
+    if(isDecoded) {
+        return ID3Util.decodeSize(Buffer.from(bytes))
+    }
+
+    return Buffer.from(bytes).readUIntBE(0, bytes.length)
+}
+
+function getFrameSize(buffer, version) {
+    return getHeaderSize(version) + getBodySize(buffer)
+}
+
+module.exports = {
+    createFromBuffer,
+    getHeaderSize,
+    getFrameSize
+}

--- a/src/ID3Helpers.js
+++ b/src/ID3Helpers.js
@@ -141,10 +141,6 @@ function getTagsFromFrames(frames, ID3Version, options = {}) {
     const raw = { }
 
     frames.forEach((frame) => {
-        if(frame.flags.encryption) {
-            return
-        }
-
         const frameValue = frame.getValue()
         const frameAlias = ID3Definitions.FRAME_INTERNAL_IDENTIFIERS.v3[frame.identifier] || ID3Definitions.FRAME_INTERNAL_IDENTIFIERS.v4[frame.identifier]
 


### PR DESCRIPTION
Currently, ID3Helper is fully responsible for parsing an ID3Frame.
The code however doesn't really make sense at that place and makes the functions very complicated.

One way of dealing with this is to extract the affected code into its own class.
The goal of this PR is to move the responsibility of parsing and writing frames into its own class.

* There is a new class `ID3Frame`. It consists of an identifier (TALB), a value ("some album") and an optional dataLengthIndicator.
* It can parse/convert a buffer to an object of its class using the `createFromBuffer` method.
* If a frame is compressed or unsynchronised, it will be handled automatically on parsing.
* By calling the `getBuffer` method, an ID3Frame object can be converted back to a buffer.
* Because header parsing is a challenge of its own, there's also a new ID3FrameHeader class which handles that.
* The ID3Helper file is cleaner and scrutinizer more happy: https://scrutinizer-ci.com/g/Zazama/node-id3/inspections/99a85b07-566b-4562-b25e-06c1a9275533

Currently implemented in this PR: reading only.