### PR TITLE
Improve index.js docs and types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -671,24 +671,106 @@ declare module "node-id3" {
             }
          }
       }
-      export function write(tags: Tags, filebuffer: Buffer): Buffer
-      export function write(tags: Tags, filebuffer: Buffer, fun: (err: null, buffer: Buffer) => void): void
-      export function write(tags: Tags, filepath: string): true | Error
-      export function write(tags: Tags, filepath: string, fn: (err: NodeJS.ErrnoException | Error | null) => void): void
-      export function create(tags: Tags): Buffer
-      export function create(tags: Tags, fn: (buffer: Buffer) => void): void
-      export function read(filebuffer: string | Buffer): Tags
-      export function read(filebuffer: string | Buffer, options: Object): Tags
-      export function read(filebuffer: string | Buffer, fn: (err: NodeJS.ErrnoException | null, tags: Tags | null) => void): void
-      export function read(filebuffer: string | Buffer, options: Object, fn: (err: NodeJS.ErrnoException | null, tags: Tags | null) => void): void
-      export function update(tags: Tags, filebuffer: Buffer, options?: Object): Buffer
-      export function update(tags: Tags, filepath: string, options?: Object): true | Error
-      export function update(tags: Tags, filepath: string, fn: (err: NodeJS.ErrnoException | Error | null) => void): void
-      export function update(tags: Tags, filepath: string, options: Object, fn: (err: NodeJS.ErrnoException | Error | null) => void): void
-      export function update(tags: Tags, filebuffer: Buffer, fn: (err: NodeJS.ErrnoException | null, buffer?: Buffer) => void): void
-      export function update(tags: Tags, filebuffer: Buffer, options: Object, fn: (err: NodeJS.ErrnoException | null, buffer?: Buffer) => void): void
-      export function removeTags(filepath: string): true | Error
-      export function removeTags(filepath: string, fn: (err: NodeJS.ErrnoException | Error | null) => void): void
+      export interface Options {
+         /**
+          * Only read the specified tag identifiers, defaults to all.
+          */
+         include?: ['TALB', 'TIT2'],
+         /**
+          * Do not read the specified tag identifiers, defaults to none.
+          */
+         exclude?: ['APIC'],
+         /**
+          * Only return the `raw` object, defaults to false.
+          */
+         onlyRaw?: boolean,
+         /**
+          * Do not generate the `raw` object, defaults to false.
+          */
+         noRaw?: boolean
+      }
+
+      export function write(
+         tags: Tags,
+         filebuffer: Buffer,
+         fn: (err: null, buffer: Buffer) => void
+      ): void
+      export function write(
+         tags: Tags,
+         filepath: string
+      ): true | Error
+      export function write(
+         tags: Tags,
+         filepath: string,
+         fn: (err: NodeJS.ErrnoException | Error | null) => void
+      ): void
+
+      export function create(
+         tags: Tags
+      ): Buffer
+      export function create(
+         tags: Tags,
+         fn: (buffer: Buffer) => void
+      ): void
+
+      export function read(
+         filebuffer: string | Buffer
+      ): Tags
+      export function read(
+         filebuffer: string | Buffer,
+         options: Options
+      ): Tags
+      export function read(
+         filebuffer: string | Buffer,
+         fn: (err: NodeJS.ErrnoException | null, tags: Tags | null) => void
+      ): void
+      export function read(
+         filebuffer: string | Buffer,
+         options: Options,
+         fn: (err: NodeJS.ErrnoException | null, tags: Tags | null
+      ) => void): void
+
+      export function update(
+         tags: Tags,
+         filebuffer: Buffer,
+         options?: Options
+      ): Buffer
+      export function update(
+         tags: Tags,
+         filepath: string,
+         options?: Options
+      ): true | Error
+      export function update(
+         tags: Tags,
+         filepath: string,
+         fn: (err: NodeJS.ErrnoException | Error | null) => void
+      ): void
+      export function update(
+         tags: Tags,
+         filepath: string,
+         options: Options,
+         fn: (err: NodeJS.ErrnoException | Error | null) => void
+      ): void
+      export function update(
+         tags: Tags,
+         filebuffer: Buffer,
+         fn: (err: NodeJS.ErrnoException | null, buffer?: Buffer
+      ) => void): void
+      export function update(
+         tags: Tags,
+         filebuffer: Buffer,
+         options: Object,
+         fn: (err: NodeJS.ErrnoException | null, buffer?: Buffer) => void
+      ): void
+
+      export function removeTags(
+         filepath: string
+      ): true | Error
+      export function removeTags(
+         filepath: string,
+         fn: (err: NodeJS.ErrnoException | Error | null) => void
+      ): void
+
       export const Promise: {
          write(tags: Tags, filebuffer: Buffer) : Promise<Buffer>,
          write(tags: Tags, filepath: string) : Promise<boolean>,

--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ const { isFunction, isString } = require('./src/util')
 */
 
 /**
- * Checks and removes already written ID3-Frames from a buffer
+ * Check and remove already written ID3-Frames from a buffer
  * @param {Buffer} data
- * @returns {boolean|Buffer}
+ * @returns {false|Buffer}
  */
 function removeTagsFromBuffer(data) {
     const framePosition = ID3Util.getFramePosition(data)
@@ -79,10 +79,10 @@ function writeSync(tags, filebuffer) {
 
 /**
  * Write passed tags to a file/buffer
- * @param tags - Object containing tags to be written
- * @param filebuffer - Can contain a filepath string or buffer
- * @param fn - (optional) Function for async version
- * @returns {boolean|Buffer|Error}
+ * @param {object} tags - Object containing tags to be written
+ * @param {string|Buffer} filebuffer - Filepath or buffer
+ * @param {WriteCallback} [fn] - Function for async version
+ * @returns {boolean|Buffer|Error|void}
  */
 function write(tags, filebuffer, fn) {
     const completeTags = create(tags)
@@ -94,10 +94,10 @@ function write(tags, filebuffer, fn) {
 }
 
 /**
- * Creates a buffer containing the ID3 Tag
- * @param tags - Object containing tags to be written
- * @param fn fn - (optional) Function for async version
- * @returns {Buffer}
+ * Create a buffer containing the ID3 Tag
+ * @param {object} tags - Object containing tags to be written
+ * @param {CreateCallback} [fn] - Function for async version
+ * @returns {Buffer|undefined}
  */
 function create(tags, fn) {
     const frames = ID3Helpers.createBufferFromTags(tags)
@@ -119,6 +119,12 @@ function create(tags, fn) {
     return id3Data
 }
 
+/**
+ * Read ID3-Tags from passed buffer/filepath
+ * @param {string|Buffer} filebuffer - Filepath or buffer
+ * @param {Options} options - Object containing options
+ * @returns {object} - Return the read tags
+ */
 function readSync(filebuffer, options) {
     if(isString(filebuffer)) {
         filebuffer = fs.readFileSync(filebuffer)
@@ -126,7 +132,14 @@ function readSync(filebuffer, options) {
     return ID3Helpers.getTagsFromBuffer(filebuffer, options)
 }
 
-function readAsync(filebuffer, options, fn) {
+/**
+ * Read ID3-Tags from passed buffer/filepath
+ * @param {string|Buffer} filebuffer - Filepath or buffer
+ * @param {Options} options - Object containing options
+ * @param {ReadCallback} fn - Function for async version
+ * @returns {void} - Return the read tags
+ */
+ function readAsync(filebuffer, options, fn) {
     if(isString(filebuffer)) {
         fs.readFile(filebuffer, (error, data) => {
             if(error) {
@@ -142,10 +155,10 @@ function readAsync(filebuffer, options, fn) {
 
 /**
  * Read ID3-Tags from passed buffer/filepath
- * @param filebuffer - Can contain a filepath string or buffer
- * @param options - (optional) Object containing options
- * @param fn - (optional) Function for async version
- * @returns {boolean}
+ * @param {string|Buffer} filebuffer - Filepath or buffer
+ * @param {Options} [options] - Object containing options
+ * @param {ReadCallback} [fn] - Function for async version
+ * @returns {boolean} - Return the read tags
  */
 function read(filebuffer, options, fn) {
     if(!options || typeof options === 'function') {
@@ -160,10 +173,10 @@ function read(filebuffer, options, fn) {
 
 /**
  * Update ID3-Tags from passed buffer/filepath
- * @param tags - Object containing tags to be written
- * @param filebuffer - Can contain a filepath string or buffer
- * @param options - (optional) Object containing options
- * @param fn - (optional) Function for async version
+ * @param {object} tags - Object containing tags to be written
+ * @param {string|Buffer} filebuffer - A filepath string or buffer
+ * @param {Options} [options] - Object containing options
+ * @param {WriteCallback} [fn] - Function for async version
  * @returns {boolean|Buffer|Error}
  */
 function update(tags, filebuffer, options, fn) {
@@ -245,7 +258,7 @@ function removeTagsSync(filepath) {
 
 /**
  * @param {string} filepath - Filepath to file
- * @param {(error: Error) => void} fn - Function for async usage
+ * @param {WriteCallback} fn - Function for async usage
  * @returns {void}
  */
 function removeTagsAsync(filepath, fn) {
@@ -272,10 +285,10 @@ function removeTagsAsync(filepath, fn) {
 }
 
 /**
- * Checks and removes already written ID3-Frames from a file
+ * Check and remove already written ID3-Frames from a file
  * @param {string} filepath - Filepath to file
- * @param fn - (optional) Function for async usage
- * @returns {boolean|Error}
+ * @param {WriteCallback} [fn] - Function for async usage
+ * @returns {boolean|Error|void}
  */
 function removeTags(filepath, fn) {
     if(isFunction(fn)) {

--- a/src/ID3Helpers.js
+++ b/src/ID3Helpers.js
@@ -69,7 +69,13 @@ module.exports.createBufferFromTags = function(tags) {
     return Buffer.concat(createBuffersFromTags(tags))
 }
 
-module.exports.getTagsFromBuffer = function(filebuffer, options) {
+/**
+ * Return a buffer with the frames for the specified tags
+ * @param {object} tags - Object containing tags to be written
+ * @param {Options} options
+ * @returns {Buffer}
+ */
+ module.exports.getTagsFromBuffer = function(filebuffer, options) {
     const framePosition = ID3Util.getFramePosition(filebuffer)
     if(framePosition === -1) {
         return getTagsFromFrames([], 3, options)

--- a/types.js
+++ b/types.js
@@ -1,0 +1,16 @@
+/**
+ * @typedef {object} Options
+ * @property {string[]} [includes] Only read the specified tag identifiers, defaults to all.
+ * @property {string[]} [excludes] Do not read the specified tag identifiers, defaults to none.
+ * @property {boolean} [onlyRaw] Only return the `raw` object, defaults to false.
+ * @property {boolean} [noRaw] Do not generate the `raw` object, defaults to false.
+ *
+ * @typedef WriteCallback
+ * @type {(error: Error) => void}
+ *
+ * @typedef ReadCallback
+ * @type {(error: Error, tags: object) => void}
+ *
+ * @typedef CreateCallback
+ * @type {(tags: object) => void}
+ */


### PR DESCRIPTION
I wanted to know what `Options` were, so I went to improve the doc a bit more.

I wanted to use ErrorCallback name instead of WriteCallback but it was conflicting with a system type, I have tried to use a JSDoc namespace but could not get it working, so changed the name for now to avoid wasting too much time to get it working.

See also
https://stackoverflow.com/questions/45836847/how-to-get-vs-code-to-understand-jsdocs-typedef-across-multiple-files/55767692

I think at some point it would be beneficial to use Typescript and compile the project to JS at export time.

I split the lines in `index.d.ts` because I was having hard times to read them and see the difference between them. Thanks.