### PR TITLE
Improve support for integer values

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ synchronisedLyrics: [{
   shortText: "Content descriptor",
   synchronisedText: [{
     text: "part 1",
-    timeStamp: 0
+    timeStamp: 0 // Must be a positive integer value
   }, {
     text: "part 2",
-    timeStamp: 1000
+    timeStamp: 1000 // Must be a positive integer value
   }]
 }]
 userDefinedText: [{
@@ -285,9 +285,10 @@ userDefinedUrl: [{
 }], // array or single object
 eventTimingCodes: {
   timeStampFormat: TagConstants.TimeStampFormat.MILLISECONDS,
-  keyEvents: [
-    { type: TagConstants.EventTimingCodes.EventType.INTRO_START, timeStamp: 1000 }
-  ]
+  keyEvents: [{
+    type: TagConstants.EventTimingCodes.EventType.INTRO_START,
+    timeStamp: 1000 // Must be a positive integer value
+  }]
 },
 commercialFrame: [{
   prices: {

--- a/src/FrameBuilder.ts
+++ b/src/FrameBuilder.ts
@@ -23,15 +23,16 @@ export class FrameBuilder {
     }
 
     appendNumber(value: number, size: number) {
-        if (Number.isInteger(value)) {
-            let hexValue = value.toString(16)
-            if (hexValue.length % 2 !== 0) {
-                hexValue = "0" + hexValue
-            }
-            this.appendBuffer(
-                staticValueToBuffer(Buffer.from(hexValue, 'hex'), size)
-            )
+        if (!Number.isInteger(value)) {
+            throw new RangeError("An integer value is expected")
         }
+        let hexValue = value.toString(16)
+        if (hexValue.length % 2 !== 0) {
+            hexValue = "0" + hexValue
+        }
+        this.appendBuffer(
+            staticValueToBuffer(Buffer.from(hexValue, 'hex'), size)
+        )
         return this
     }
 

--- a/src/types/Tags.ts
+++ b/src/types/Tags.ts
@@ -349,7 +349,8 @@ export interface TagAliases {
         synchronisedText: {
             text: string,
             /**
-             * Absolute time in unit according to `timeStampFormat`.
+             * A positive integer expressing an absolute time in unit according
+             * to `timeStampFormat`.
              */
             timeStamp: number
         }[]
@@ -503,7 +504,8 @@ export interface TagAliases {
              */
             type: number,
             /**
-             * Absolute time in unit according to `timeStampFormat`.
+             * A positive integer expressing an absolute time in unit according
+             * to `timeStampFormat`.
              */
             timeStamp: number
         }[]


### PR DESCRIPTION
The documentation does not specify that the `timeStamp` values must be an integer.
When the values are not an integer the `appendNumber` function silently omit to write the value and creates an invalid encoded buffer.

- update the documentation to specify that the `timeStamp` must be a positive integer
- update the `appendNumber` function to throw a `RangeError` when the given value is not an integer instead of creating an invalid buffer

fixes #146 
