### PR TITLE
Refactor frame reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ The library may throw in various cases.
 - file operations may throw, refer to [Node.js](https://nodejs.org/) File System
   API for information
 - tags are partially validated and the API will throw when a validation fails
+- read operations will ignore frames with decoding errors, i.e. frames which do
+  not comply to the specification
 
 ## Supported aliases/fields
 

--- a/src/Frame.ts
+++ b/src/Frame.ts
@@ -118,14 +118,19 @@ function makeValueArray(identifier: string, data: unknown) {
 }
 
 function makeFrameValue(identifier:string, body: Buffer, version: number) {
-    if (isKeyOf(identifier, Frames)) {
-        return Frames[identifier].read(body, version)
-    }
-    if (identifier.startsWith('T')) {
-        return GenericFrames.GENERIC_TEXT.read(body)
-    }
-    if (identifier.startsWith('W')) {
-        return GenericFrames.GENERIC_URL.read(body)
+    try {
+        if (isKeyOf(identifier, Frames)) {
+            return Frames[identifier].read(body, version)
+        }
+        if (identifier.startsWith('T')) {
+            return GenericFrames.GENERIC_TEXT.read(body)
+        }
+        if (identifier.startsWith('W')) {
+            return GenericFrames.GENERIC_URL.read(body)
+        }
+    } catch(error) {
+        // On read ignore frames with errors
+        return null
     }
     return null
 }

--- a/src/FrameBuilder.ts
+++ b/src/FrameBuilder.ts
@@ -47,6 +47,10 @@ export class FrameBuilder {
         return this
     }
 
+    getBuffer() {
+        return this.buffer
+    }
+
     getBufferWithPartialHeader() {
         const header = Buffer.alloc(10)
         header.write(this.identifier, 0)

--- a/src/FrameBuilder.ts
+++ b/src/FrameBuilder.ts
@@ -47,7 +47,7 @@ export class FrameBuilder {
         return this
     }
 
-    getBuffer() {
+    getBufferWithPartialHeader() {
         const header = Buffer.alloc(10)
         header.write(this.identifier, 0)
         header.writeUInt32BE(this.buffer.length, 4)

--- a/src/FrameReader.ts
+++ b/src/FrameReader.ts
@@ -9,7 +9,7 @@ type FrameReaderOptions = {
 }
 
 export class FrameReader {
-    private _encoding: number
+    private _encoding: TextEncoding
     private _splitBuffer: SplitBuffer
 
     constructor(
@@ -20,8 +20,8 @@ export class FrameReader {
     ) {
         if (consumeEncodingByte) {
             const encodingBytePosition = 0
-            this._encoding =
-                buffer[encodingBytePosition] ?? TextEncoding.ISO_8859_1
+            this._encoding = buffer[encodingBytePosition] as TextEncoding ??
+                TextEncoding.ISO_8859_1
             if (consumeEncodingByte) {
                 buffer = encodingBytePosition === 0 ?
                     buffer.subarray(1) :
@@ -34,6 +34,13 @@ export class FrameReader {
             this._encoding = TextEncoding.ISO_8859_1
         }
         this._splitBuffer = new SplitBuffer(null, buffer.subarray(0))
+    }
+
+    consumeString({ size, encoding = this._encoding }: {
+        size?: number
+        encoding?: TextEncoding
+    } = {}): string {
+        return this.consumeStaticValue('string', size, encoding)
     }
 
     consumeStaticValue(

--- a/src/FrameReader.ts
+++ b/src/FrameReader.ts
@@ -1,7 +1,12 @@
 import { SplitBuffer, } from "./ID3Util"
 import * as ID3Util from "./ID3Util"
+import { TextEncoding } from "./definitions/Encoding"
 
 type DataType = "string" | "number" | "buffer"
+
+type FrameReaderOptions = {
+    consumeEncodingByte?: boolean
+}
 
 export class FrameReader {
     private _encoding: number
@@ -9,17 +14,14 @@ export class FrameReader {
 
     constructor(
         buffer: Buffer,
-        encodingBytePosition?: number,
-        consumeEncodingByte = true
+        {
+            consumeEncodingByte = false
+        }: FrameReaderOptions = {}
     ) {
-        if (!buffer || !(buffer instanceof Buffer)) {
-            buffer = Buffer.alloc(0)
-        }
-        if (
-            encodingBytePosition !== undefined &&
-            Number.isInteger(encodingBytePosition)
-        ) {
-            this._encoding = buffer[encodingBytePosition] ? buffer[encodingBytePosition] : 0x00
+        if (consumeEncodingByte) {
+            const encodingBytePosition = 0
+            this._encoding =
+                buffer[encodingBytePosition] ?? TextEncoding.ISO_8859_1
             if (consumeEncodingByte) {
                 buffer = encodingBytePosition === 0 ?
                     buffer.subarray(1) :
@@ -29,7 +31,7 @@ export class FrameReader {
                     ])
             }
         } else {
-            this._encoding = 0x00
+            this._encoding = TextEncoding.ISO_8859_1
         }
         this._splitBuffer = new SplitBuffer(null, buffer.subarray(0))
     }

--- a/src/FrameReader.ts
+++ b/src/FrameReader.ts
@@ -1,16 +1,17 @@
-import { SplitBuffer, } from "./ID3Util"
 import * as ID3Util from "./ID3Util"
 import { TextEncoding } from "./definitions/Encoding"
-
-type DataType = "string" | "number" | "buffer"
 
 type FrameReaderOptions = {
     consumeEncodingByte?: boolean
 }
 
+type Size = {
+    size?: number
+}
+
 export class FrameReader {
-    private _encoding: TextEncoding
-    private _splitBuffer: SplitBuffer
+    private _encoding: TextEncoding = TextEncoding.ISO_8859_1
+    private _buffer: Buffer
 
     constructor(
         buffer: Buffer,
@@ -18,146 +19,92 @@ export class FrameReader {
             consumeEncodingByte = false
         }: FrameReaderOptions = {}
     ) {
+        this._buffer = buffer
         if (consumeEncodingByte) {
-            const encodingBytePosition = 0
-            this._encoding = buffer[encodingBytePosition] as TextEncoding ??
-                TextEncoding.ISO_8859_1
-            if (consumeEncodingByte) {
-                buffer = encodingBytePosition === 0 ?
-                    buffer.subarray(1) :
-                    Buffer.concat([
-                        buffer.subarray(0, encodingBytePosition),
-                        buffer.subarray(encodingBytePosition)
-                    ])
-            }
-        } else {
-            this._encoding = TextEncoding.ISO_8859_1
+            const encoding = this.consumeBuffer({ size: 1 })
+            this._encoding = encoding[0] as TextEncoding
         }
-        this._splitBuffer = new SplitBuffer(null, buffer.subarray(0))
     }
 
-    consumeString({ size, encoding = this._encoding }: {
+    isBufferEmpty() {
+        return this._buffer.length === 0
+    }
+
+    consumePossiblyEmptyBuffer(
+        { size = this._buffer.length }: Size = {}
+    ): Buffer {
+        if (size > this._buffer.length) {
+            throw new RangeError(
+                `Requested size ${size} larger than the buffer size ${this._buffer.length}`
+            )
+        }
+        const consumed = this._buffer.subarray(0, size)
+        this._buffer = this._buffer.subarray(size)
+        return consumed
+    }
+
+    consumeBuffer(size?: Size): Buffer {
+        if (this._buffer.length === 0) {
+            throw new RangeError("Buffer empty")
+        }
+        return this.consumePossiblyEmptyBuffer(size)
+    }
+
+    consumeNumber({ size }: { size: number }): number {
+        const buffer = this.consumeBuffer({ size })
+        return parseInt(buffer.toString('hex'), 16)
+    }
+
+    consumeText({ size, encoding = TextEncoding.ISO_8859_1 }: {
         size?: number
         encoding?: TextEncoding
     } = {}): string {
-        return this.consumeStaticValue('string', size, encoding)
-    }
-
-    consumeStaticValue(
-        dataType: 'string',
-        size?: number | null,
-        encoding?: number
-    ): string
-    consumeStaticValue(
-        dataType: 'number',
-        size?: number | null,
-        encoding?: number
-    ): number
-    consumeStaticValue(
-        dataType: 'buffer',
-        size?: number | null,
-        encoding?: number
-    ): Buffer
-    consumeStaticValue(
-    ): Buffer
-    consumeStaticValue(
-        dataType: DataType = 'buffer',
-        size?: number | null,
-        encoding = this._encoding
-    ) {
-        return this._consumeByFunction(
-            // TODO check if this._splitBuffer.remainder can be null!
-            // eslint-disable-next-line
-            () => staticValueFromBuffer(this._splitBuffer.remainder!, size),
-            dataType,
-            encoding
-        )
-    }
-
-    consumeNullTerminatedValue(
-        dataType: 'string',
-        encoding?: number
-     ): string
-     consumeNullTerminatedValue(
-        dataType: 'number',
-        encoding?: number
-     ): number
-    consumeNullTerminatedValue(
-        dataType: DataType,
-        encoding = this._encoding
-    ) {
-        return this._consumeByFunction(
-            () => ID3Util.splitNullTerminatedBuffer(
-                // TODO check if this._splitBuffer.remainder can be null!
-                // eslint-disable-next-line
-                this._splitBuffer.remainder!,
-                encoding
-            ),
-            dataType,
-            encoding
-        )
-    }
-
-    private _consumeByFunction(
-        fn: () => SplitBuffer,
-        dataType: DataType,
-        encoding: number
-    ) {
-        if (
-            !this._splitBuffer.remainder ||
-            this._splitBuffer.remainder.length === 0
-        ) {
-            return undefined
-        }
-        this._splitBuffer = fn()
-        if (dataType) {
-            return convertValue(this._splitBuffer.value, dataType, encoding)
-        }
-        return this._splitBuffer.value
-    }
-}
-
-function convertValue(
-    buffer: Buffer | number | string | null,
-    dataType: DataType,
-    encoding = 0x00
-) {
-    // TODO: Check this behaviour:
-    // - if 0 or an empty string is given it will return `undefined`
-    //   I don't think this should behave that way.
-    //   I would think this test should not exist, the following one
-    //   !(buffer instanceof Buffer)) should be sufficient and more correct,
-    //   removing this test would:
-    //   - return 0 if 0 is given (instead of undefined)
-    //   - return "" if "" is given (instead of undefined)
-    //   - return null if null is given (instead of undefined)
-    if (!buffer) {
-        return undefined
-    }
-    if (!(buffer instanceof Buffer)) {
-        return buffer
-    }
-    if (buffer.length === 0) {
-        return undefined
-    }
-    if (dataType === "number") {
-        return parseInt(buffer.toString('hex'), 16)
-    }
-    if (dataType === "string") {
+        const buffer = this.consumeBuffer({ size })
         return ID3Util.bufferToDecodedString(buffer, encoding)
     }
-    return buffer
+
+    consumeTextWithFrameEncoding(size: Size = {}): string {
+        return this.consumeText({...size, encoding: this._encoding})
+    }
+
+    consumeTerminatedText(
+        encoding: TextEncoding = TextEncoding.ISO_8859_1
+    ): string {
+        const [consumed, remainder] =
+            splitNullTerminatedBuffer(this._buffer, encoding)
+        this._buffer = remainder
+        return ID3Util.bufferToDecodedString(consumed, encoding)
+    }
+
+    consumeTerminatedTextWithFrameEncoding(): string {
+        return this.consumeTerminatedText(this._encoding)
+    }
 }
 
-function staticValueFromBuffer(
+/**
+ * @param buffer A buffer starting with a null-terminated text string.
+ * @param encoding The encoding type in which the text string is encoded.
+ * @returns A split buffer containing the bytes before and after the null
+ *          termination. If no null termination is found, considers that
+ *          the buffer was not containing a text string and returns
+ *          the given buffer as the remainder in the split buffer.
+ */
+export function splitNullTerminatedBuffer(
     buffer: Buffer,
-    size?: number | null
-): SplitBuffer {
-    size = size ?? buffer.length
-    if (buffer.length > size) {
-        return new SplitBuffer(
-            buffer.subarray(0, size), buffer.subarray(size)
-        )
+    encoding: TextEncoding
+) {
+    const charSize = ([
+        TextEncoding.UTF_16_WITH_BOM,
+        TextEncoding.UTF_16_BE
+    ] as number[]).includes(encoding) ? 2 : 1
+
+    for (let pos = 0; pos <= buffer.length - charSize; pos += charSize) {
+        if (buffer.readUIntBE(pos, charSize) === 0) {
+            return [
+                buffer.subarray(0, pos),
+                buffer.subarray(pos + charSize)
+            ] as const
+        }
     }
-    return new SplitBuffer(buffer.subarray(0), null)
+    throw new RangeError("Terminating character not found")
 }

--- a/src/ID3Util.ts
+++ b/src/ID3Util.ts
@@ -1,45 +1,6 @@
 import iconv = require('iconv-lite')
 import { FrameOptions, FRAME_OPTIONS } from './definitions/FrameOptions'
 import { isKeyOf, isString } from './util'
-import { TextEncoding } from './definitions/Encoding'
-
-export class SplitBuffer {
-    value: Buffer | null
-    remainder: Buffer | null
-    constructor(value: Buffer | null = null, remainder: Buffer | null = null) {
-        this.value = value
-        this.remainder = remainder
-    }
-}
-
-/**
- * @param buffer A buffer starting with a null-terminated text string.
- * @param encoding The encoding type in which the text string is encoded.
- * @returns A split buffer containing the bytes before and after the null
- *          termination. If no null termination is found, considers that
- *          the buffer was not containing a text string and returns
- *          the given buffer as the remainder in the split buffer.
- */
-export function splitNullTerminatedBuffer(
-    buffer: Buffer,
-    encoding: number = TextEncoding.ISO_8859_1
-) {
-    const charSize = ([
-        TextEncoding.UTF_16_WITH_BOM,
-        TextEncoding.UTF_16_BE
-    ] as number[]).includes(encoding) ? 2 : 1
-
-    for (let pos = 0; pos <= buffer.length - charSize; pos += charSize) {
-        if (buffer.readUIntBE(pos, charSize) === 0) {
-            return new SplitBuffer(
-                buffer.subarray(0, pos),
-                buffer.subarray(pos + charSize)
-            )
-        }
-    }
-
-    return new SplitBuffer(null, buffer.subarray(0))
-}
 
 export function encodingFromStringOrByte(encoding: string | number) {
     const ENCODINGS = [

--- a/src/api/create.ts
+++ b/src/api/create.ts
@@ -1,7 +1,7 @@
-import * as ID3Util from "../ID3Util"
 import { WriteTags } from "../types/Tags"
 import { isFunction } from  "../util"
 import { createBufferFromTags } from "../TagsHelpers"
+import { createId3Data } from "../id3-data"
 
 /**
  * Callback used to return a buffer with the created ID Tag.
@@ -26,18 +26,7 @@ export function create(tags: WriteTags): Buffer
 export function create(tags: WriteTags, callback: CreateCallback): void
 
 export function create(tags: WriteTags, callback?: CreateCallback) {
-    const frames = createBufferFromTags(tags)
-
-    //  Creates ID3 header
-    const header = Buffer.alloc(10)
-    header.fill(0)
-    header.write("ID3", 0)              // File identifier
-    header.writeUInt16BE(0x0300, 3)     // Version 2.3.0  --  03 00
-    header.writeUInt16BE(0x0000, 5)     // Flags 00
-    ID3Util.encodeSize(frames.length).copy(header, 6)
-
-    const id3Data = Buffer.concat([header, frames])
-
+    const id3Data = createId3Data(createBufferFromTags(tags))
     if (isFunction(callback)) {
         return callback(id3Data)
     }

--- a/src/frames/frame-apic.ts
+++ b/src/frames/frame-apic.ts
@@ -46,17 +46,17 @@ export const APIC = {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             mime: version === 2
-                ? reader.consumeString({size: 3, encoding: TextEncoding.ISO_8859_1})
-                : reader.consumeNullTerminatedValue('string', TextEncoding.ISO_8859_1),
+                ? reader.consumeText({size: 3})
+                : reader.consumeTerminatedText(),
             type: (() => {
-                const typeId = reader.consumeStaticValue('number', 1)
+                const typeId = reader.consumeNumber({size: 1})
                 return {
                     id: typeId,
                     name: APIC_TYPES[typeId]
                 }
             })(),
-            description: reader.consumeNullTerminatedValue('string'),
-            imageBuffer: reader.consumeStaticValue()
+            description: reader.consumeTerminatedTextWithFrameEncoding(),
+            imageBuffer: reader.consumePossiblyEmptyBuffer()
         }
     }
 }

--- a/src/frames/frame-apic.ts
+++ b/src/frames/frame-apic.ts
@@ -43,7 +43,7 @@ export const APIC = {
             .getBuffer()
     },
     read: (buffer: Buffer, version: number): Image => {
-        const reader = new FrameReader(buffer, 0)
+        const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             mime: version === 2
                 ? reader.consumeStaticValue('string', 3, TextEncoding.ISO_8859_1)

--- a/src/frames/frame-apic.ts
+++ b/src/frames/frame-apic.ts
@@ -46,7 +46,7 @@ export const APIC = {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             mime: version === 2
-                ? reader.consumeStaticValue('string', 3, TextEncoding.ISO_8859_1)
+                ? reader.consumeString({size: 3, encoding: TextEncoding.ISO_8859_1})
                 : reader.consumeNullTerminatedValue('string', TextEncoding.ISO_8859_1),
             type: (() => {
                 const typeId = reader.consumeStaticValue('number', 1)

--- a/src/frames/frame-apic.ts
+++ b/src/frames/frame-apic.ts
@@ -40,7 +40,7 @@ export const APIC = {
                 ?? TagConstants.AttachedPicture.PictureType.FRONT_COVER, 1)
             .appendNullTerminatedValue(description, textEncoding)
             .appendValue(image.pictureBuffer)
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer, version: number): Image => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})

--- a/src/frames/frame-chap.ts
+++ b/src/frames/frame-chap.ts
@@ -25,24 +25,24 @@ export const CHAP = {
     read: (buffer: Buffer): Chapter<Tags> => {
         const reader = new FrameReader(buffer)
 
-        const consumeNumber = () => reader.consumeStaticValue('number', 4)
+        const consumeNumber = () => reader.consumeNumber({size: 4})
 
         const makeOffset = (value: number) => value === 0xFFFFFFFF ? null : value
 
-        const elementID = reader.consumeNullTerminatedValue('string')
+        const elementID = reader.consumeTerminatedText()
         const startTimeMs = consumeNumber()
         const endTimeMs = consumeNumber()
         const startOffsetBytes = makeOffset(consumeNumber())
         const endOffsetBytes = makeOffset(consumeNumber())
-        const tags =
-            TagsHelpers.getTagsFromTagBody(reader.consumeStaticValue()) as Tags
         return {
             elementID,
             startTimeMs,
             endTimeMs,
             ...startOffsetBytes === null ? {} : {startOffsetBytes},
             ...endOffsetBytes === null ? {} : {endOffsetBytes},
-            tags
+            tags: TagsHelpers.getTagsFromTagBody(
+                reader.consumePossiblyEmptyBuffer()
+            ) as Tags
         }
     }
 }

--- a/src/frames/frame-chap.ts
+++ b/src/frames/frame-chap.ts
@@ -25,6 +25,8 @@ export const CHAP = {
     read: (buffer: Buffer): Chapter<Tags> => {
         const reader = new FrameReader(buffer)
 
+        // Returns a spreadable object to insert an optional offset property
+        // when the consumed offset is valid.
         const consumeOffset= <Key extends keyof Chapter<never>>(key: Key) => {
             const offset = reader.consumeNumber({size: 4})
             return offset === 0xFFFFFFFF ? {} : {[key]: offset}

--- a/src/frames/frame-chap.ts
+++ b/src/frames/frame-chap.ts
@@ -20,7 +20,7 @@ export const CHAP = {
             .appendNumber(getOffset(chap.startOffsetBytes), 4)
             .appendNumber(getOffset(chap.endOffsetBytes), 4)
             .appendValue(TagsHelpers.createBufferFromTags(chap.tags))
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): Chapter<Tags> => {
         const reader = new FrameReader(buffer)

--- a/src/frames/frame-comm.ts
+++ b/src/frames/frame-comm.ts
@@ -15,7 +15,7 @@ export const COMM = {
             .appendValue(validateLanguage(data.language))
             .appendNullTerminatedValue(data.shortText, textEncoding)
             .appendValue(data.text, null, textEncoding)
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): Comment => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})

--- a/src/frames/frame-comm.ts
+++ b/src/frames/frame-comm.ts
@@ -18,7 +18,7 @@ export const COMM = {
             .getBuffer()
     },
     read: (buffer: Buffer): Comment => {
-        const reader = new FrameReader(buffer, 0)
+        const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             language: reader.consumeStaticValue('string', 3, TextEncoding.ISO_8859_1),
             shortText: reader.consumeNullTerminatedValue('string'),

--- a/src/frames/frame-comm.ts
+++ b/src/frames/frame-comm.ts
@@ -20,9 +20,9 @@ export const COMM = {
     read: (buffer: Buffer): Comment => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
-            language: reader.consumeString({size: 3, encoding: TextEncoding.ISO_8859_1}),
-            shortText: reader.consumeNullTerminatedValue('string'),
-            text: reader.consumeString()
+            language: reader.consumeText({size: 3}),
+            shortText: reader.consumeTerminatedTextWithFrameEncoding(),
+            text: reader.consumeTextWithFrameEncoding()
         }
     }
 }

--- a/src/frames/frame-comm.ts
+++ b/src/frames/frame-comm.ts
@@ -20,9 +20,9 @@ export const COMM = {
     read: (buffer: Buffer): Comment => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
-            language: reader.consumeStaticValue('string', 3, TextEncoding.ISO_8859_1),
+            language: reader.consumeString({size: 3, encoding: TextEncoding.ISO_8859_1}),
             shortText: reader.consumeNullTerminatedValue('string'),
-            text: reader.consumeStaticValue('string', null)
+            text: reader.consumeString()
         }
     }
 }

--- a/src/frames/frame-comr.ts
+++ b/src/frames/frame-comr.ts
@@ -61,7 +61,8 @@ export const COMR = {
             )
 
         // Valid until
-        const validUntilString = reader.consumeStaticValue('string', 8, 0x00)
+        const validUntilString =
+            reader.consumeString({size: 8, encoding: TextEncoding.ISO_8859_1})
         const validUntil = { year: 0, month: 0, day: 0 }
         if(/^\d+$/.test(validUntilString)) {
             validUntil.year = parseInt(validUntilString.substring(0, 4))

--- a/src/frames/frame-comr.ts
+++ b/src/frames/frame-comr.ts
@@ -43,7 +43,7 @@ export const COMR = {
             builder.appendNullTerminatedValue(mimeType, TextEncoding.ISO_8859_1)
             builder.appendValue(pictureBuffer)
         }
-        return builder.getBuffer()
+        return builder.getBufferWithPartialHeader()
     },
 
     read: (buffer: Buffer): CommercialFrame => {

--- a/src/frames/frame-comr.ts
+++ b/src/frames/frame-comr.ts
@@ -47,7 +47,7 @@ export const COMR = {
     },
 
     read: (buffer: Buffer): CommercialFrame => {
-        const reader = new FrameReader(buffer, 0)
+        const reader = new FrameReader(buffer, {consumeEncodingByte: true})
 
         const prices = reader.consumeNullTerminatedValue('string', 0x00)
             .split('/')

--- a/src/frames/frame-ctoc.ts
+++ b/src/frames/frame-ctoc.ts
@@ -38,15 +38,15 @@ export const CTOC = {
 
         const elementID = reader.consumeTerminatedText()
         const flags = reader.consumeNumber({size: 1})
+
         const entries = reader.consumeNumber({size: 1})
         const elements = []
         for(let i = 0; i < entries; i++) {
             elements.push(reader.consumeTerminatedText())
         }
-        const tags =
-            TagsHelpers.getTagsFromTagBody(
-                reader.consumePossiblyEmptyBuffer()
-            ) as Tags
+        const tags = TagsHelpers.getTagsFromTagBody(
+            reader.consumePossiblyEmptyBuffer()
+        ) as Tags
 
         return {
             elementID,

--- a/src/frames/frame-ctoc.ts
+++ b/src/frames/frame-ctoc.ts
@@ -36,15 +36,17 @@ export const CTOC = {
     read: (buffer: Buffer): TableOfContents<Tags> => {
         const reader = new FrameReader(buffer)
 
-        const elementID = reader.consumeNullTerminatedValue('string')
-        const flags = reader.consumeStaticValue('number', 1)
-        const entries = reader.consumeStaticValue('number', 1)
+        const elementID = reader.consumeTerminatedText()
+        const flags = reader.consumeNumber({size: 1})
+        const entries = reader.consumeNumber({size: 1})
         const elements = []
         for(let i = 0; i < entries; i++) {
-            elements.push(reader.consumeNullTerminatedValue('string'))
+            elements.push(reader.consumeTerminatedText())
         }
         const tags =
-            TagsHelpers.getTagsFromTagBody(reader.consumeStaticValue()) as Tags
+            TagsHelpers.getTagsFromTagBody(
+                reader.consumePossiblyEmptyBuffer()
+            ) as Tags
 
         return {
             elementID,

--- a/src/frames/frame-ctoc.ts
+++ b/src/frames/frame-ctoc.ts
@@ -31,7 +31,7 @@ export const CTOC = {
         if (toc.tags) {
             builder.appendValue(TagsHelpers.createBufferFromTags(toc.tags))
         }
-        return builder.getBuffer()
+        return builder.getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): TableOfContents<Tags> => {
         const reader = new FrameReader(buffer)

--- a/src/frames/frame-etco.ts
+++ b/src/frames/frame-etco.ts
@@ -11,7 +11,7 @@ export const ETCO = {
                 .appendNumber(keyEvent.type, 1)
                 .appendNumber(keyEvent.timeStamp, 4)
         })
-        return builder.getBuffer()
+        return builder.getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): EventTimingCodes => {
         const reader = new FrameReader(buffer)

--- a/src/frames/frame-etco.ts
+++ b/src/frames/frame-etco.ts
@@ -16,17 +16,14 @@ export const ETCO = {
     read: (buffer: Buffer): EventTimingCodes => {
         const reader = new FrameReader(buffer)
         return {
-            timeStampFormat: reader.consumeStaticValue(
-                'number', 1
-            ) as EventTimingCodes["timeStampFormat"],
+            timeStampFormat: reader.consumeNumber({size: 1}) as
+                EventTimingCodes["timeStampFormat"],
             keyEvents: Array.from((function*() {
-                while(true) {
-                    const type = reader.consumeStaticValue('number', 1)
-                    const timeStamp = reader.consumeStaticValue('number', 4)
-                    if (type === undefined || timeStamp === undefined) {
-                        break
+                while(!reader.isBufferEmpty()) {
+                    yield {
+                        type: reader.consumeNumber({size: 1}),
+                        timeStamp: reader.consumeNumber({size: 4})
                     }
-                    yield {type, timeStamp}
                 }
             })())
         }

--- a/src/frames/frame-popm.ts
+++ b/src/frames/frame-popm.ts
@@ -34,7 +34,7 @@ export const POPM = {
             .appendNullTerminatedValue(data.email)
             .appendNumber(rating, 1)
             .appendNumber(counter, 4)
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): Popularimeter => {
         const reader = new FrameReader(buffer)

--- a/src/frames/frame-popm.ts
+++ b/src/frames/frame-popm.ts
@@ -39,9 +39,9 @@ export const POPM = {
     read: (buffer: Buffer): Popularimeter => {
         const reader = new FrameReader(buffer)
         return {
-            email: reader.consumeNullTerminatedValue('string'),
-            rating: reader.consumeStaticValue('number', 1),
-            counter: reader.consumeStaticValue('number')
+            email: reader.consumeTerminatedText(),
+            rating: reader.consumeNumber({size: 1}),
+            counter: reader.consumeNumber({size: 4})
         }
     }
 }

--- a/src/frames/frame-priv.ts
+++ b/src/frames/frame-priv.ts
@@ -13,8 +13,8 @@ export const PRIV = {
     read: (buffer: Buffer): Private => {
         const reader = new FrameReader(buffer)
         return {
-            ownerIdentifier: reader.consumeNullTerminatedValue('string'),
-            data: reader.consumeStaticValue()
+            ownerIdentifier: reader.consumeTerminatedText(),
+            data: reader.consumePossiblyEmptyBuffer()
         }
     }
 }

--- a/src/frames/frame-priv.ts
+++ b/src/frames/frame-priv.ts
@@ -8,7 +8,7 @@ export const PRIV = {
         return new FrameBuilder("PRIV")
             .appendNullTerminatedValue(priv.ownerIdentifier)
             .appendValue(isBuffer(priv.data) ? priv.data : Buffer.from(priv.data, "utf8"))
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): Private => {
         const reader = new FrameReader(buffer)

--- a/src/frames/frame-sylt.ts
+++ b/src/frames/frame-sylt.ts
@@ -19,7 +19,7 @@ export const SYLT = {
             frameBuilder.appendNullTerminatedValue(part.text, textEncoding)
             frameBuilder.appendNumber(part.timeStamp, 4)
         })
-        return frameBuilder.getBuffer()
+        return frameBuilder.getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): SynchronisedLyrics => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})

--- a/src/frames/frame-sylt.ts
+++ b/src/frames/frame-sylt.ts
@@ -4,6 +4,8 @@ import { FrameReader } from "../FrameReader"
 import { SynchronisedLyrics } from "../types/TagFrames"
 import { validateLanguage } from "./util"
 
+type TimeStampFormat = SynchronisedLyrics["timeStampFormat"]
+
 export const SYLT = {
     create: (lyrics: SynchronisedLyrics): Buffer => {
         const textEncoding = TextEncoding.UTF_16_WITH_BOM
@@ -23,8 +25,7 @@ export const SYLT = {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             language: reader.consumeText({ size: 3}),
-            timeStampFormat: reader.consumeNumber({size: 1}) as
-                SynchronisedLyrics["timeStampFormat"],
+            timeStampFormat: reader.consumeNumber({size: 1}) as TimeStampFormat,
             contentType: reader.consumeNumber({size: 1}),
             shortText: reader.consumeTerminatedTextWithFrameEncoding(),
             synchronisedText: Array.from((function*() {

--- a/src/frames/frame-sylt.ts
+++ b/src/frames/frame-sylt.ts
@@ -20,7 +20,7 @@ export const SYLT = {
         return frameBuilder.getBuffer()
     },
     read: (buffer: Buffer): SynchronisedLyrics => {
-        const reader = new FrameReader(buffer, 0)
+        const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             language: reader.consumeStaticValue('string', 3, 0x00),
             timeStampFormat: reader.consumeStaticValue('number', 1) as

--- a/src/frames/frame-sylt.ts
+++ b/src/frames/frame-sylt.ts
@@ -22,7 +22,7 @@ export const SYLT = {
     read: (buffer: Buffer): SynchronisedLyrics => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
-            language: reader.consumeStaticValue('string', 3, 0x00),
+            language: reader.consumeString({ size: 3, encoding: TextEncoding.ISO_8859_1 }),
             timeStampFormat: reader.consumeStaticValue('number', 1) as
                 SynchronisedLyrics["timeStampFormat"],
             contentType: reader.consumeStaticValue('number', 1),

--- a/src/frames/frame-txxx.ts
+++ b/src/frames/frame-txxx.ts
@@ -16,7 +16,7 @@ export const TXXX = {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             description: reader.consumeNullTerminatedValue('string'),
-            value: reader.consumeStaticValue('string')
+            value: reader.consumeString()
         }
     }
 }

--- a/src/frames/frame-txxx.ts
+++ b/src/frames/frame-txxx.ts
@@ -13,7 +13,7 @@ export const TXXX = {
             .getBuffer()
     },
     read: (buffer: Buffer): UserDefinedText => {
-        const reader = new FrameReader(buffer, 0)
+        const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             description: reader.consumeNullTerminatedValue('string'),
             value: reader.consumeStaticValue('string')

--- a/src/frames/frame-txxx.ts
+++ b/src/frames/frame-txxx.ts
@@ -15,8 +15,8 @@ export const TXXX = {
     read: (buffer: Buffer): UserDefinedText => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
-            description: reader.consumeNullTerminatedValue('string'),
-            value: reader.consumeString()
+            description: reader.consumeTerminatedTextWithFrameEncoding(),
+            value: reader.consumeTextWithFrameEncoding()
         }
     }
 }

--- a/src/frames/frame-txxx.ts
+++ b/src/frames/frame-txxx.ts
@@ -10,7 +10,7 @@ export const TXXX = {
             .appendNumber(textEncoding, 1)
             .appendNullTerminatedValue(udt.description, textEncoding)
             .appendValue(udt.value, null, textEncoding)
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): UserDefinedText => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})

--- a/src/frames/frame-ufid.ts
+++ b/src/frames/frame-ufid.ts
@@ -10,7 +10,7 @@ export const UFID = {
                 ufid.identifier instanceof Buffer ?
                 ufid.identifier : Buffer.from(ufid.identifier, "utf8")
             )
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): UniqueFileIdentifier => {
         const reader = new FrameReader(buffer)

--- a/src/frames/frame-ufid.ts
+++ b/src/frames/frame-ufid.ts
@@ -15,8 +15,8 @@ export const UFID = {
     read: (buffer: Buffer): UniqueFileIdentifier => {
         const reader = new FrameReader(buffer)
         return {
-            ownerIdentifier: reader.consumeNullTerminatedValue('string'),
-            identifier: reader.consumeStaticValue()
+            ownerIdentifier: reader.consumeTerminatedText(),
+            identifier: reader.consumePossiblyEmptyBuffer()
         }
     }
 }

--- a/src/frames/frame-uslt.ts
+++ b/src/frames/frame-uslt.ts
@@ -28,7 +28,7 @@ export const USLT = {
             .getBuffer()
     },
     read: (buffer: Buffer): UnsynchronisedLyrics => {
-        const reader = new FrameReader(buffer, 0)
+        const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             language: reader.consumeStaticValue(
                 'string', 3, TextEncoding.ISO_8859_1

--- a/src/frames/frame-uslt.ts
+++ b/src/frames/frame-uslt.ts
@@ -30,11 +30,11 @@ export const USLT = {
     read: (buffer: Buffer): UnsynchronisedLyrics => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
-            language: reader.consumeStaticValue(
-                'string', 3, TextEncoding.ISO_8859_1
+            language: reader.consumeString(
+                { size: 3, encoding: TextEncoding.ISO_8859_1 }
             ),
             shortText: reader.consumeNullTerminatedValue('string'),
-            text: reader.consumeStaticValue('string', null)
+            text: reader.consumeString()
         }
     }
 }

--- a/src/frames/frame-uslt.ts
+++ b/src/frames/frame-uslt.ts
@@ -30,11 +30,9 @@ export const USLT = {
     read: (buffer: Buffer): UnsynchronisedLyrics => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
-            language: reader.consumeString(
-                { size: 3, encoding: TextEncoding.ISO_8859_1 }
-            ),
-            shortText: reader.consumeNullTerminatedValue('string'),
-            text: reader.consumeString()
+            language: reader.consumeText({ size: 3}),
+            shortText: reader.consumeTerminatedTextWithFrameEncoding(),
+            text: reader.consumeTextWithFrameEncoding()
         }
     }
 }

--- a/src/frames/frame-uslt.ts
+++ b/src/frames/frame-uslt.ts
@@ -25,7 +25,7 @@ export const USLT = {
             .appendValue(validateLanguage(data.language), 3, TextEncoding.ISO_8859_1)
             .appendNullTerminatedValue(data.shortText, textEncoding)
             .appendValue(data.text, null, textEncoding)
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): UnsynchronisedLyrics => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})

--- a/src/frames/frame-wxxx.ts
+++ b/src/frames/frame-wxxx.ts
@@ -13,7 +13,7 @@ export const WXXX = {
             .getBuffer()
     },
     read: (buffer: Buffer): UserDefinedUrl => {
-        const reader = new FrameReader(buffer, 0)
+        const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             description: reader.consumeNullTerminatedValue('string'),
             url: reader.consumeStaticValue('string', null, TextEncoding.ISO_8859_1)

--- a/src/frames/frame-wxxx.ts
+++ b/src/frames/frame-wxxx.ts
@@ -15,8 +15,8 @@ export const WXXX = {
     read: (buffer: Buffer): UserDefinedUrl => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
-            description: reader.consumeNullTerminatedValue('string'),
-            url: reader.consumeString({ encoding: TextEncoding.ISO_8859_1 })
+            description: reader.consumeTerminatedTextWithFrameEncoding(),
+            url: reader.consumeText()
         }
     }
 }

--- a/src/frames/frame-wxxx.ts
+++ b/src/frames/frame-wxxx.ts
@@ -16,7 +16,7 @@ export const WXXX = {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
         return {
             description: reader.consumeNullTerminatedValue('string'),
-            url: reader.consumeStaticValue('string', null, TextEncoding.ISO_8859_1)
+            url: reader.consumeString({ encoding: TextEncoding.ISO_8859_1 })
         }
     }
 }

--- a/src/frames/frame-wxxx.ts
+++ b/src/frames/frame-wxxx.ts
@@ -10,7 +10,7 @@ export const WXXX = {
             .appendNumber(textEncoding, 1)
             .appendNullTerminatedValue(data.description, textEncoding)
             .appendValue(data.url, null, TextEncoding.ISO_8859_1)
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer): UserDefinedUrl => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})

--- a/src/frames/generic.ts
+++ b/src/frames/generic.ts
@@ -15,7 +15,7 @@ export const GENERIC_TEXT = {
             .getBuffer()
     },
     read: (buffer: Buffer) => {
-        const reader = new FrameReader(buffer, 0)
+        const reader = new FrameReader(buffer, {consumeEncodingByte: true})
 
         return reader.consumeStaticValue('string')
     }

--- a/src/frames/generic.ts
+++ b/src/frames/generic.ts
@@ -16,7 +16,7 @@ export const GENERIC_TEXT = {
     },
     read: (buffer: Buffer) => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
-        return reader.consumeString()
+        return reader.consumeTextWithFrameEncoding()
     }
 }
 
@@ -32,6 +32,6 @@ export const GENERIC_URL = {
     },
     read: (buffer: Buffer) => {
         const reader = new FrameReader(buffer)
-        return reader.consumeString()
+        return reader.consumeText()
     }
 }

--- a/src/frames/generic.ts
+++ b/src/frames/generic.ts
@@ -12,7 +12,7 @@ export const GENERIC_TEXT = {
         return new FrameBuilder(frameIdentifier)
             .appendNumber(textEncoding, 1)
             .appendValue(text, null, textEncoding)
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer) => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
@@ -28,7 +28,7 @@ export const GENERIC_URL = {
 
         return new FrameBuilder(frameIdentifier)
             .appendValue(url)
-            .getBuffer()
+            .getBufferWithPartialHeader()
     },
     read: (buffer: Buffer) => {
         const reader = new FrameReader(buffer)

--- a/src/frames/generic.ts
+++ b/src/frames/generic.ts
@@ -16,8 +16,7 @@ export const GENERIC_TEXT = {
     },
     read: (buffer: Buffer) => {
         const reader = new FrameReader(buffer, {consumeEncodingByte: true})
-
-        return reader.consumeStaticValue('string')
+        return reader.consumeString()
     }
 }
 
@@ -33,7 +32,6 @@ export const GENERIC_URL = {
     },
     read: (buffer: Buffer) => {
         const reader = new FrameReader(buffer)
-
-        return reader.consumeStaticValue('string')
+        return reader.consumeString()
     }
 }

--- a/src/id3-data.ts
+++ b/src/id3-data.ts
@@ -1,0 +1,12 @@
+import { encodeSize } from "./ID3Util"
+
+export function createId3Data(frames: Buffer) {
+    const header = Buffer.alloc(10)
+    header.fill(0)
+    header.write("ID3", 0)              // File identifier
+    header.writeUInt16BE(0x0300, 3)     // Version 2.3.0  --  03 00
+    header.writeUInt16BE(0x0000, 5)     // Flags 00
+    encodeSize(frames.length).copy(header, 6)
+
+    return Buffer.concat([header, frames])
+}

--- a/src/types/TagFrames.ts
+++ b/src/types/TagFrames.ts
@@ -550,7 +550,7 @@ export type SynchronisedLyrics = {
  * @public
  */
 export type UserDefinedText = {
-    description: string,
+    description?: string,
     value: string
 }
 
@@ -576,7 +576,7 @@ Picture data    <binary data>
     /**
      * See https://en.wikipedia.org/wiki/ID3#ID3v2_embedded_image_extension
      */
-    type: {
+    type?: {
         /**
          * {@link TagConstants.AttachedPicture.PictureType}
          */
@@ -613,7 +613,7 @@ export type Popularimeter = {
  * @public
  */
 export type Private = {
-    ownerIdentifier: string,
+    ownerIdentifier?: string,
     data: Buffer
 }
 

--- a/src/types/TagFrames.ts
+++ b/src/types/TagFrames.ts
@@ -470,7 +470,7 @@ export type Comment = {
 }
 
 /**
- * Unsychronised lyrics/text transcription
+ * Unsychronised lyrics/text transcription `USLT` frame
  *
  * @remarks
  * This frame contains the lyrics of the song or a text transcription of

--- a/test/frame-apic.ts
+++ b/test/frame-apic.ts
@@ -56,9 +56,7 @@ describe('NodeID3 APIC frame', function () {
             const withoutDescription = Buffer.from("494433030000000000264150494300000012000000696D6167652F6A70656700030061626364", "hex")
 
             const imageWithoutDescription = {
-                // TODO: read should return either no description property
-                // or an empty string, this is closer to ID3 documentation.
-                description: undefined,
+                description: "",
                 imageBuffer: Buffer.from([0x61, 0x62, 0x63, 0x64]),
                 mime: "image/jpeg",
                 type: {

--- a/test/frame-errors.ts
+++ b/test/frame-errors.ts
@@ -1,0 +1,21 @@
+import * as NodeID3 from '../index'
+import assert = require('assert')
+import { expect } from 'chai'
+import { createId3Data } from '../src/id3-data'
+import { FrameBuilder } from '../src/FrameBuilder'
+import { Frames } from '../src/frames/frames'
+
+describe('Frames with errors', function () {
+    it('reading an invalid private frame throws', function() {
+        const invalidPrivateFrameBuffer = new FrameBuilder('PRIV').getBuffer()
+        const readInvalidFrame =
+            () => Frames['PRIV'].read(invalidPrivateFrameBuffer)
+        expect(readInvalidFrame).to.throw()
+    }),
+    it('a frame with a decode error is ignored', function () {
+        const invalidPrivateFrame = new FrameBuilder('PRIV').getBufferWithPartialHeader()
+        const id3Data = createId3Data(invalidPrivateFrame)
+        const readFrames = NodeID3.read(id3Data, {noRaw: true})
+        assert.deepStrictEqual(readFrames, {})
+    })
+})

--- a/test/frame-with-optionals.ts
+++ b/test/frame-with-optionals.ts
@@ -1,0 +1,106 @@
+import * as NodeID3 from '../index'
+import assert = require('assert')
+
+const createAndRead = (frames: NodeID3.WriteTags) =>
+    NodeID3.read(NodeID3.create(frames), {noRaw: true})
+
+describe('Frames with optional values', function () {
+    it('comment frame', function () {
+        assert.deepStrictEqual(createAndRead({
+            comment: {
+                language: 'eng',
+                text: 'comment text'
+            },
+        }), {
+            comment: {
+                language: 'eng',
+                shortText: '',
+                text: 'comment text'
+            }
+        })
+    })
+    it('userDefinedText frame', function() {
+        assert.deepStrictEqual(createAndRead({
+            userDefinedText: [{
+                value: "TXXX value text"
+            }, {
+                value: "TXXX value text 2"
+            }]
+        }), {
+            userDefinedText: [{
+                description: '',
+                value: "TXXX value text"
+            }, {
+                description: '',
+                value: "TXXX value text 2"
+            }]
+        })
+    })
+    it('image frame', function() {
+        assert.deepStrictEqual(createAndRead({
+            image: {
+                mime: "image/jpeg",
+                imageBuffer: Buffer.from([0x02, 0x27, 0x17, 0x99])
+            }
+        }), {
+            image: {
+                description: "",
+                mime: "image/jpeg",
+                type: {
+                    id: NodeID3.TagConstants.AttachedPicture.PictureType.FRONT_COVER,
+                    name: "front cover"
+                },
+                imageBuffer: Buffer.from([0x02, 0x27, 0x17, 0x99])
+            },
+        })
+    })
+    it('private frame', function() {
+        assert.deepStrictEqual(createAndRead({
+            private: [{
+                data: Buffer.from("private-buffer")
+            }, {
+                data: Buffer.from([0x01, 0x02, 0x05])
+            }],
+        }), {
+            private: [{
+                ownerIdentifier: '',
+                data: Buffer.from("private-buffer")
+            }, {
+                ownerIdentifier: '',
+                data: Buffer.from([0x01, 0x02, 0x05])
+            }],
+
+        })
+    }),
+    it('chapter frame', function() {
+        assert.deepStrictEqual(createAndRead({
+            chapter: [{
+                elementID: "chapter 1",
+                startTimeMs: 5000,
+                endTimeMs: 8000
+            }],
+        }), {
+            chapter: [{
+                elementID: "chapter 1",
+                startTimeMs: 5000,
+                endTimeMs: 8000,
+                tags: { raw: {} }
+            }],
+        })
+    }),
+    it('tableOfContents frame', function() {
+        assert.deepStrictEqual(createAndRead({
+            tableOfContents: [{
+                elementID: "toc 1",
+                elements: ['chap1']
+            }],
+        }), {
+            tableOfContents: [{
+                elementID: "toc 1",
+                elements: ['chap1'],
+                isOrdered: false,
+                tags: { raw: {} }
+            }],
+        })
+    })
+})

--- a/test/jsmediatags-cross-tests.ts
+++ b/test/jsmediatags-cross-tests.ts
@@ -269,44 +269,5 @@ describe('Cross tests jsmediatags', function () {
         }
         assert.deepStrictEqual(nodeTagsFull, read)
     })
-
-    it('read from missing values self-created tags', function () {
-        const tagsBuffer = NodeID3.create(
-            nodeTagsMissingValues as unknown as NodeID3.WriteTags
-        )
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const read: any = NodeID3.read(tagsBuffer, {noRaw: true})
-
-        assert.deepStrictEqual(read.chapter[0].tags.raw, {})
-
-        delete read.chapter[0].tags
-        if (!read.comment.shortText) {
-            delete read.comment.shortText
-        }
-        if (!read.image.description) {
-            delete read.image.description
-        }
-        delete read.image.type
-        assert.strictEqual(read.popularimeter.rating, 1)
-
-        if (read.private[0].ownerIdentifier === undefined) {
-            delete read.private[0].ownerIdentifier
-        }
-        if (read.private[1].ownerIdentifier === undefined) {
-            delete read.private[1].ownerIdentifier
-        }
-        assert.strictEqual(read.tableOfContents[0].isOrdered, false)
-        assert.deepStrictEqual(read.tableOfContents[0].tags.raw, {})
-
-        delete read.tableOfContents[0].tags
-        delete read.tableOfContents[0].isOrdered
-        if (!read.userDefinedText[0].description) {
-            delete read.userDefinedText[0].description
-        }
-        if (!read.userDefinedText[1].description) {
-            delete read.userDefinedText[1].description
-        }
-        assert.deepStrictEqual(nodeTagsMissingValues, read)
-    })
 })
 

--- a/test/jsmediatags-cross-tests.ts
+++ b/test/jsmediatags-cross-tests.ts
@@ -101,12 +101,12 @@ const nodeTagsMissingValues = {
         data: Buffer.from([0x01, 0x02, 0x05])
     }],
     chapter: [{
-        elementID: "Hey!", // THIS MUST BE UNIQUE!
+        elementID: "chapter 1", // THIS MUST BE UNIQUE!
         startTimeMs: 5000,
         endTimeMs: 8000
     }],
     tableOfContents: [{
-        elementID: "toc1",    // THIS MUST BE UNIQUE!
+        elementID: "toc 1",    // THIS MUST BE UNIQUE!
         elements: ['chap1']
     }],
 }
@@ -275,9 +275,8 @@ describe('Cross tests jsmediatags', function () {
             nodeTagsMissingValues as unknown as NodeID3.WriteTags
         )
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const read: any = NodeID3.read(tagsBuffer)
+        const read: any = NodeID3.read(tagsBuffer, {noRaw: true})
 
-        delete read.raw
         assert.deepStrictEqual(read.chapter[0].tags.raw, {})
 
         delete read.chapter[0].tags


### PR DESCRIPTION
This PR is mostly to simplify and refactor the `FrameReader` class.

- simpler implementation
- clearer and simpler interface
- less error prone interface (named parameters, typed encoding)
- new implementation is not completely equivalent to the old one, differences are
  - does not try to be robust to error in frames and throws instead
  - does not return undefined when no data and throws instead
- update frames read()
- fix tests to match the new behaviour

Each commit message has more detail.

Probably best to review with **Hide white space changes**.