### PR TITLE
Improve id3 tag

### DIFF
--- a/src/id3-tag.ts
+++ b/src/id3-tag.ts
@@ -8,10 +8,11 @@ const Header = {
     identifier: "ID3",
     size: 10,
     offset: {
-        id: 0,
-        version: 3,
-        flags: 5,
-        size: 6
+        identifier: 0,  // 3 bytes
+        version: 3,     // major version: 1 byte
+        revision: 4,    // 1 byte
+        flags: 5,       // 1 byte
+        size: 6         // 4 bytes
     }
 } as const
 
@@ -26,7 +27,7 @@ export function createId3Tag(tags: WriteTags) {
 export function embedFramesInId3Tag(frames: Buffer) {
     const header = Buffer.alloc(Header.size)
     header.fill(0)
-    header.write(Header.identifier, Header.offset.id)
+    header.write(Header.identifier, Header.offset.identifier)
     header.writeUInt16BE(0x0300, Header.offset.version)
     header.writeUInt16BE(0x0000, Header.offset.flags)
     encodeSize(frames.length).copy(header, Header.offset.size)

--- a/src/id3-tag.ts
+++ b/src/id3-tag.ts
@@ -124,27 +124,22 @@ function parseTagHeaderFlags(header: Buffer) {
 }
 
 /**
- * Returns -1 if no tag was found.
+ * Returns the position of the first valid tag found or -1 if no tag was found.
  */
 function findId3TagPosition(buffer: Buffer) {
     // Search Buffer for valid ID3 frame
     let position = -1
-    let headerValid = false
     do {
         position = buffer.indexOf(Header.identifier, position + 1)
         if (position !== -1) {
             // It's possible that there is a "ID3" sequence without being an
             // ID3 Frame, so we need to check for validity of the next 10 bytes.
-            headerValid = isValidId3Header(
-                buffer.subarray(position, position + Header.size)
-            )
+            if (isValidId3Header(buffer.subarray(position))) {
+                return position
+            }
         }
-    } while (position !== -1 && !headerValid)
-
-    if (!headerValid) {
-        return -1
-    }
-    return position
+    } while (position !== -1)
+    return -1
 }
 
 function isValidId3Header(buffer: Buffer) {


### PR DESCRIPTION
A series of small improvements to id3-tag.

- Simplify findId3TagPosition()
- Improve isValidId3Header()]
- Complete more Header constants
- Split getId3TagBody()
  - Attempt to make bits of the code more re-usable.