### PR TITLE
Improve Test Coverage

### DIFF
--- a/src/api/remove.ts
+++ b/src/api/remove.ts
@@ -26,7 +26,7 @@ export type RemoveCallback =
  *
  * @public
  */
-export function removeTags(filepath: string): boolean | Error
+export function removeTags(filepath: string): true | Error
 
 /**
  * Removes asynchronously any written ID3-Frames from the specified file.
@@ -51,9 +51,6 @@ function removeTagsSync(filepath: string) {
     }
 
     const newData = removeTagsFromBuffer(data)
-    if(!newData) {
-        return false
-    }
 
     try {
         fs.writeFileSync(filepath, newData, 'binary')
@@ -72,10 +69,6 @@ function removeTagsAsync(filepath: string, callback: RemoveCallback) {
         }
 
         const newData = removeTagsFromBuffer(data)
-        if(!newData) {
-            callback(error)
-            return
-        }
 
         fs.writeFile(filepath, newData, 'binary', (error) => {
             if(error) {

--- a/src/api/update.ts
+++ b/src/api/update.ts
@@ -6,6 +6,17 @@ import { updateTags } from '../updateTags'
 import { write, WriteCallback } from "./write"
 
 /**
+ * Updates ID3-Tags asynchronously in the specified file.
+ *
+ * @public
+ */
+export function update(
+    tags: WriteTags,
+    filebuffer: string | Buffer,
+    callback: WriteCallback
+): void
+
+/**
  * Updates ID3-Tags from the given buffer.
  *
  * @public
@@ -26,17 +37,6 @@ import { write, WriteCallback } from "./write"
     filepath: string,
     options?: Options
 ): true | Error
-
-/**
- * Updates ID3-Tags asynchronously in the specified file.
- *
- * @public
- */
- export function update(
-    tags: WriteTags,
-    filebuffer: string | Buffer,
-    callback: WriteCallback
-): void
 
 /**
  * Updates ID3-Tags asynchronously from the given buffer or specified file.

--- a/src/id3-tag.ts
+++ b/src/id3-tag.ts
@@ -92,10 +92,6 @@ export function removeId3Tag(data: Buffer) {
     }
     const encodedSize = subarray(data, tagPosition + Header.offset.size, 4)
 
-    if (!isValidEncodedSize(encodedSize)) {
-        return false
-    }
-
     if (data.length >= tagPosition + Header.size) {
         const size = decodeSize(encodedSize)
         return Buffer.concat([

--- a/test/api/remove.ts
+++ b/test/api/remove.ts
@@ -1,0 +1,70 @@
+import * as NodeID3 from '../../index'
+import assert = require('assert')
+import chai = require('chai')
+import * as fs from 'fs'
+
+describe('NodeID3 API', function () {
+    describe('#removeTags()', function() {
+        const nonExistingFilepath = './hopefully-does-not-exist.mp3'
+        it('sync not existing filepath', function() {
+            chai.assert.isFalse(fs.existsSync(nonExistingFilepath))
+            chai.assert.instanceOf(
+                NodeID3.removeTags(nonExistingFilepath), Error
+            )
+        })
+        it('async not existing filepath', function() {
+            chai.assert.isFalse(fs.existsSync(nonExistingFilepath))
+            NodeID3.removeTags(nonExistingFilepath, function(err) {
+                if(!(err instanceof Error)) {
+                    assert.fail("No error thrown on non-existing filepath")
+                }
+            })
+        })
+
+        const titleTag = {
+            title: "abc"
+        } satisfies NodeID3.WriteTags
+        const filepath = './testfile.mp3'
+
+        describe('valid buffer', function() {
+            const prefixBuffer = Buffer.from([0x01, 0x02, 0x03])
+            const postfixBuffer = Buffer.from([0x04, 0x05, 0x06])
+            const buffer = Buffer.concat([
+                prefixBuffer,
+                NodeID3.create(titleTag),
+                postfixBuffer
+            ])
+            const bufferAfterRemove = Buffer.concat([
+                prefixBuffer,
+                postfixBuffer
+            ])
+
+            beforeEach(function() {
+                fs.writeFileSync(filepath, buffer)
+            })
+
+            afterEach(function() {
+                fs.unlinkSync(filepath)
+            })
+
+            it('sync remove tags from file', function() {
+                NodeID3.removeTags(filepath)
+                assert.deepStrictEqual(
+                    fs.readFileSync(filepath),
+                    bufferAfterRemove
+                )
+            })
+
+            it('async remove tags from file', function(done) {
+                NodeID3.removeTags(filepath, (err) => {
+                    assert.equal(err, null)
+                    assert.deepStrictEqual(
+                        fs.readFileSync(filepath),
+                        bufferAfterRemove
+                    )
+                    done()
+                })
+            })
+        })
+    })
+})

--- a/test/api/update.ts
+++ b/test/api/update.ts
@@ -1,0 +1,45 @@
+import * as NodeID3 from '../../index'
+import assert = require('assert')
+import chai = require('chai')
+import * as fs from 'fs'
+import { WriteCallback } from '../../index'
+
+describe('NodeID3 API', function () {
+    describe('#update()', function() {
+        const titleTag = {
+            title: "abc"
+        } satisfies NodeID3.WriteTags
+        const albumTag = {
+            album: "def"
+        }
+        const tags = {...titleTag, ...albumTag}
+        const filepath = './testfile.mp3'
+
+        beforeEach(function() {
+            fs.writeFileSync(filepath, NodeID3.create(titleTag))
+        })
+
+        it('sync add tag to existing', function() {
+            chai.assert.isTrue(NodeID3.update(albumTag, filepath))
+            assert.deepStrictEqual(
+                NodeID3.read(filepath, {noRaw: true}),
+                tags
+            )
+        })
+
+        it('async add tag to existing', function(done) {
+            NodeID3.update(albumTag, filepath, (error, data) => {
+                chai.assert.isNull(error)
+                assert.deepStrictEqual(
+                    NodeID3.read(filepath, {noRaw: true}),
+                    tags
+                )
+                done()
+            })
+        })
+
+        afterEach(function() {
+            fs.unlinkSync(filepath)
+        })
+    })
+})

--- a/test/api/update.ts
+++ b/test/api/update.ts
@@ -38,6 +38,40 @@ describe('NodeID3 API', function () {
             })
         })
 
+        it('compare key', function() {
+            const beforeTags = {
+                userDefinedText: [{
+                    description: 'description',
+                    value: 'some value'
+                }],
+                private: [{
+                    ownerIdentifier: 'ownerIdentifier',
+                    data: Buffer.from('data')
+                }]
+            } satisfies NodeID3.Tags
+            const addTags = {
+                userDefinedText: [{
+                    description: 'description',
+                    value: 'some other value'
+                }],
+                private: {
+                    ownerIdentifier: 'ownerIdentifier',
+                    data: Buffer.from('data2')
+                }
+            } satisfies NodeID3.Tags
+            const afterTags = {
+                userDefinedText: addTags.userDefinedText,
+                private: [...beforeTags.private, addTags.private]
+            } satisfies NodeID3.Tags
+            const beforeBuffer = NodeID3.create(beforeTags)
+            const afterBuffer = NodeID3.update(addTags, beforeBuffer)
+
+            assert.deepStrictEqual(
+                NodeID3.read(afterBuffer, {noRaw: true}),
+                afterTags
+            )
+        })
+
         afterEach(function() {
             fs.unlinkSync(filepath)
         })


### PR DESCRIPTION
- Removes unreachable ID3 Tag header validity check in the remove API, because an ID3 Tag is only found when its header is valid
- Add tests for `NodeID3.removeTags`
- Add tests for all `NodeID3.update` API branches
    - Reorder types to allow for calling `NodeID3.update(tags, filepath, callback)` (without options)
- Add tests for frame builder throws
- Add tests for tags whose data can be changed in frame builder (e.g. undefined => empty string)
- Add tests for update compare key