### PR TITLE
Validate text encoding and cleanup util-text-encoding

### DIFF
--- a/src/FrameReader.ts
+++ b/src/FrameReader.ts
@@ -1,5 +1,5 @@
 import { TextEncoding } from "./definitions/Encoding"
-import { bufferToDecodedString } from "./util-text-encoding"
+import { bufferToDecodedString, validateEncoding } from "./util-text-encoding"
 
 type FrameReaderOptions = {
     consumeEncodingByte?: boolean
@@ -22,7 +22,7 @@ export class FrameReader {
         this._buffer = buffer
         if (consumeEncodingByte) {
             const encoding = this.consumeBuffer({ size: 1 })
-            this._encoding = encoding[0] as TextEncoding
+            this._encoding = validateEncoding(encoding[0])
         }
     }
 

--- a/src/util-text-encoding.ts
+++ b/src/util-text-encoding.ts
@@ -21,16 +21,21 @@ export function bufferToDecodedString(
     ).replace(/\0/g, '')
 }
 
+const TO_ICON_ENCODING = {
+    [TextEncoding.ISO_8859_1]: 'ISO-8859-1',
+    [TextEncoding.UTF_16_WITH_BOM]: 'UTF-16',
+    [TextEncoding.UTF_16_BE]: 'UTF-16BE',
+    [TextEncoding.UTF_8]: 'UTF-8'
+} satisfies Record<TextEncoding, string>
+
+export function validateEncoding(encoding: number): TextEncoding {
+    if (encoding in TO_ICON_ENCODING) {
+        return encoding as TextEncoding
+    }
+    throw new RangeError(`Unknown encoding value ${encoding}`)
+}
+
 function convertTextEncodingToIconEncoding(encoding: TextEncoding) {
-    const toIconvEncoding = {
-        [TextEncoding.ISO_8859_1]: 'ISO-8859-1',
-        [TextEncoding.UTF_16_WITH_BOM]: 'UTF-16',
-        [TextEncoding.UTF_16_BE]: 'UTF-16BE',
-        [TextEncoding.UTF_8]: 'UTF-8'
-    }
-    if (toIconvEncoding[encoding]) {
-        return toIconvEncoding[encoding]
-    }
-    throw new RangeError(`Unknown encoding value ${encoding}, can't decode`)
+    return TO_ICON_ENCODING[validateEncoding(encoding)]
 }
 

--- a/src/util-text-encoding.ts
+++ b/src/util-text-encoding.ts
@@ -1,40 +1,36 @@
 import iconv = require('iconv-lite')
-import { isString } from "./util"
+import { TextEncoding } from './definitions/Encoding'
 
 export function stringToEncodedBuffer(
     value: string,
-    encodingByte: string | number
+    encoding: TextEncoding
 ) {
     return iconv.encode(
         value,
-        encodingFromStringOrByte(encodingByte)
+        convertTextEncodingToIconEncoding(encoding)
     )
 }
 
 export function bufferToDecodedString(
     buffer: Buffer,
-    encodingByte: string | number
+    encoding: TextEncoding
 ) {
     return iconv.decode(
         buffer,
-        encodingFromStringOrByte(encodingByte)
+        convertTextEncodingToIconEncoding(encoding)
     ).replace(/\0/g, '')
 }
 
-function encodingFromStringOrByte(encoding: string | number) {
-    const ENCODINGS = [
-        'ISO-8859-1', 'UTF-16', 'UTF-16BE', 'UTF-8'
-    ]
-
-    if (isString(encoding) && ENCODINGS.includes(encoding)) {
-        return encoding
+function convertTextEncodingToIconEncoding(encoding: TextEncoding) {
+    const toIconvEncoding = {
+        [TextEncoding.ISO_8859_1]: 'ISO-8859-1',
+        [TextEncoding.UTF_16_WITH_BOM]: 'UTF-16',
+        [TextEncoding.UTF_16_BE]: 'UTF-16BE',
+        [TextEncoding.UTF_8]: 'UTF-8'
     }
-    if (
-        typeof encoding === "number" &&
-        encoding >= 0 && encoding < ENCODINGS.length
-    ) {
-        return ENCODINGS[encoding]
+    if (toIconvEncoding[encoding]) {
+        return toIconvEncoding[encoding]
     }
-    return ENCODINGS[0]
+    throw new RangeError(`Unknown encoding value ${encoding}, can't decode`)
 }
 


### PR DESCRIPTION
This PR is to continue to clean-up the existing code and adding more validations on the data.
When the data is invalid, throws to fails the decoding instead of having an undefined behaviour.
The frame will be ignored.

Cleanup util-text-encoding:

- remove unnecessary string parameter
- move robust conversion table
- improve names
- throws instead of fallback as this is unknown behaviour
  (unless id3 specs document it otherwise)

Validate encoding when reading frame: rather than silently falling back to ISO-8859-1 throws, we can't decode a frame in the encoding is unknown.
