### PR TITLE
For GEOB frames, use latin1 encoding

### DIFF
--- a/src/ID3Frames.js
+++ b/src/ID3Frames.js
@@ -562,11 +562,11 @@ module.exports.GEOB = {
             }
         })
 
-        const encoding = 0x00 // latin1 (ISO-8859-1)
+        const encoding = 0x01 // 16 bit unicode
         return Buffer.concat(data.map((geob) => {
             return new ID3FrameBuilder("GEOB")
                 .appendStaticNumber(encoding)
-                .appendNullTerminatedValue(geob.mimeType ? geob.mimeType : '')
+                .appendNullTerminatedValue(geob.mimeType ? geob.mimeType : '', 0x00)
                 .appendNullTerminatedValue(geob.filename ? geob.filename : '', encoding)
                 .appendNullTerminatedValue(geob.contentDescription, encoding)
                 .appendStaticValue(geob.encapsulatedObject)

--- a/src/ID3Frames.js
+++ b/src/ID3Frames.js
@@ -562,7 +562,7 @@ module.exports.GEOB = {
             }
         })
 
-        const encoding = 0x01 // UTF-16 BOM
+        const encoding = 0x00 // latin1 (ISO-8859-1)
         return Buffer.concat(data.map((geob) => {
             return new ID3FrameBuilder("GEOB")
                 .appendStaticNumber(encoding)

--- a/src/ID3Frames.js
+++ b/src/ID3Frames.js
@@ -562,7 +562,7 @@ module.exports.GEOB = {
             }
         })
 
-        const encoding = 0x01 // 16 bit unicode
+        const encoding = 0x01 // UTF-16 BOM
         return Buffer.concat(data.map((geob) => {
             return new ID3FrameBuilder("GEOB")
                 .appendStaticNumber(encoding)


### PR DESCRIPTION
Fix encoding of GEOB frames: https://github.com/Zazama/node-id3/issues/187