### PR TITLE
Fix PNG image MIME detection

### DIFF
--- a/src/ID3Util.js
+++ b/src/ID3Util.js
@@ -227,7 +227,7 @@ module.exports.processUnsynchronisedBuffer = function(buffer) {
 module.exports.getPictureMimeTypeFromBuffer = function(pictureBuffer) {
     if (pictureBuffer.length > 3 && pictureBuffer.compare(Buffer.from([0xff, 0xd8, 0xff]), 0, 3, 0, 3) === 0) {
         return "image/jpeg"
-    } else if (pictureBuffer > 8 && pictureBuffer.compare(Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]), 0, 8, 0, 8) === 0) {
+    } else if (pictureBuffer.length > 8 && pictureBuffer.compare(Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]), 0, 8, 0, 8) === 0) {
         return "image/png"
     } else {
         return null

--- a/test/test.js
+++ b/test/test.js
@@ -126,6 +126,19 @@ describe('NodeID3', function () {
             ), 0)
         })
 
+        it('detects PNG image buffers', function() {
+            const pngHeader = Buffer.from([
+                0x89, 0x50, 0x4E, 0x47,
+                0x0D, 0x0A, 0x1A, 0x0A,
+                0x00
+            ])
+
+            assert.strictEqual(
+                ID3Util.getPictureMimeTypeFromBuffer(pngHeader),
+                'image/png'
+            )
+        })
+
         it('create APIC frame', function() {
             const tags = {
                 image: {


### PR DESCRIPTION
PNG image MIME auto-detection was incorrectly checking:

`pictureBuffer > 8`

instead of:

`pictureBuffer.length > 8`

As a result, valid PNG image buffers were not detected correctly and `getPictureMimeTypeFromBuffer()` returned `null`.

This change fixes the length check and adds regression coverage for PNG image buffer detection.

Focused verification:
`npm test`
